### PR TITLE
Aggregate parameters & descriptions from multiple snippets (closes #63)

### DIFF
--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -271,12 +271,12 @@ object OpenApi20Generator {
                     ).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.requestParameters }
-                                .distinct()
+                                .distinctBy { it.name }
                                 .map { requestParameterDescriptor2Parameter(it)
                                 }).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.headers }
-                                .distinct()
+                                .distinctBy { it.name }
                                 .map { header2Parameter(it)
                             }
                     ).plus(

--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -267,7 +267,7 @@ object OpenApi20Generator {
             produces = modelsWithSamePathAndMethod.map { it.response.contentType }.distinct().filterNotNull().nullIfEmpty()
             parameters =
                     extractPathParameters(
-                        modelsWithSamePathAndMethod
+                        firstModelForPathAndMethod
                     ).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.requestParameters }
@@ -312,16 +312,14 @@ object OpenApi20Generator {
         }
     }
 
-    private fun extractPathParameters(resourceModel: List<ResourceModel>): List<PathParameter> {
-        val pathParameterNames = resourceModel
-            .map { it.request.path }
-            .flatMap { it.split("/") }
+    private fun extractPathParameters(resourceModel: ResourceModel): List<PathParameter> {
+        val pathParameterNames = resourceModel.request.path
+            .split("/")
             .filter { it.startsWith("{") && it.endsWith("}") }
             .map { it.removePrefix("{").removeSuffix("}") }
-            .distinct()
 
         return pathParameterNames.map { parameterName ->
-            resourceModel.flatMap { it.request.pathParameters }
+            resourceModel.request.pathParameters
                 .firstOrNull { it.name == parameterName }
                 ?.let { pathParameterDescriptor2Parameter(it) }
                 ?: parameterName2PathParameter(parameterName)

--- a/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
+++ b/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
@@ -145,7 +145,7 @@ class OpenApi20GeneratorTest {
 
         then(params).anyMatch { it.name == "id" }
         then(params).anyMatch { it.name == "locale" }
-        then(params).anyMatch { it.name == "color" }
+        then(params).anyMatch { it.name == "color" && it.description == "Changes the color of the product" }
         then(params).anyMatch { it.name == "Authorization" }
         then(params).hasSize(4) // should not contain duplicated parameter descriptions
 
@@ -450,7 +450,17 @@ class OpenApi20GeneratorTest {
                         privateResource = false,
                         deprecated = false,
                         tags = setOf("tag1", "tag2"),
-                        request = getProductRequestWithDifferentParameter(),
+                        request = getProductRequestWithDifferentParameter("color", "Changes the color of the product"),
+                        response = getProduct200Response(getProductPayloadExample())
+                ),
+                ResourceModel(
+                        operationId = "test-1",
+                        summary = "summary 1",
+                        description = "description 1",
+                        privateResource = false,
+                        deprecated = false,
+                        tags = setOf("tag1", "tag2"),
+                        request = getProductRequestWithDifferentParameter("color", "Modifies the color of the product"),
                         response = getProduct200Response(getProductPayloadExample())
                 )
         )
@@ -588,11 +598,11 @@ class OpenApi20GeneratorTest {
         )
     }
 
-    private fun getProductRequestWithDifferentParameter(): RequestModel {
+    private fun getProductRequestWithDifferentParameter(name: String, description: String): RequestModel {
         return getProductRequest().copy(requestParameters = listOf(
                 ParameterDescriptor(
-                        name = "color",
-                        description = "Changes the color of the product",
+                        name = name,
+                        description = description,
                         type = "STRING",
                         optional = true,
                         ignored = false

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -227,16 +227,12 @@ object OpenApi3Generator {
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.requestParameters }
                                 .distinct()
-                                .map { requestParameterDescriptor2Parameter(
-                                        it
-                                )
+                                .map { requestParameterDescriptor2Parameter(it)
                     }).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.headers }
                                 .distinct()
-                                .map { header2Parameter(
-                                        it
-                                )
+                                .map { header2Parameter(it)
                         }
                     ).nullIfEmpty()
             requestBody = resourceModelsToRequestBody(

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -226,12 +226,12 @@ object OpenApi3Generator {
                     ).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.requestParameters }
-                                .distinct()
+                                .distinctBy { it.name }
                                 .map { requestParameterDescriptor2Parameter(it)
                     }).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.headers }
-                                .distinct()
+                                .distinctBy { it.name }
                                 .map { header2Parameter(it)
                         }
                     ).nullIfEmpty()

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -222,7 +222,7 @@ object OpenApi3Generator {
             deprecated = if (modelsWithSamePathAndMethod.all { it.deprecated }) true else null
             parameters =
                     extractPathParameters(
-                        modelsWithSamePathAndMethod
+                        firstModelForPathAndMethod
                     ).plus(
                         modelsWithSamePathAndMethod
                                 .flatMap { it.request.requestParameters }
@@ -339,15 +339,14 @@ object OpenApi3Generator {
             .examples(examplesWithOperationId.map { it.key to Example().apply { value(it.value) } }.toMap().nullIfEmpty())
     }
 
-    private fun extractPathParameters(resourceModels: List<ResourceModel>): List<PathParameter> {
-        val pathParameterNames = resourceModels.map { it.request.path }
-            .flatMap { it.split("/") }
+    private fun extractPathParameters(resourceModel: ResourceModel): List<PathParameter> {
+        val pathParameterNames = resourceModel.request.path
+            .split("/")
             .filter { it.startsWith("{") && it.endsWith("}") }
             .map { it.removePrefix("{").removeSuffix("}") }
-            .distinct()
 
         return pathParameterNames.map { parameterName ->
-            resourceModels.flatMap { it.request.pathParameters }
+            resourceModel.request.pathParameters
                 .firstOrNull { it.name == parameterName }
                 ?.let { pathParameterDescriptor2Parameter(it) }
                 ?: parameterName2PathParameter(parameterName)

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -128,7 +128,7 @@ class OpenApi3GeneratorTest {
 
         then(params).anyMatch { it["name"] == "id" }
         then(params).anyMatch { it["name"] == "locale" }
-        then(params).anyMatch { it["name"] == "color" }
+        then(params).anyMatch { it["name"] == "color" && it["description"] == "Changes the color of the product" }
         then(params).anyMatch { it["name"] == "Authorization" }
         then(params).hasSize(4) // should not contain duplicated parameter descriptions
 
@@ -280,7 +280,17 @@ class OpenApi3GeneratorTest {
                         privateResource = false,
                         deprecated = false,
                         tags = setOf("tag1", "tag2"),
-                        request = getProductRequestWithDifferentParameter(),
+                        request = getProductRequestWithDifferentParameter("color", "Changes the color of the product"),
+                        response = getProductResponse()
+                ),
+                ResourceModel(
+                        operationId = "test-1",
+                        summary = "summary 1",
+                        description = "description 1",
+                        privateResource = false,
+                        deprecated = false,
+                        tags = setOf("tag1", "tag2"),
+                        request = getProductRequestWithDifferentParameter("color", "Modifies the color of the product"),
                         response = getProductResponse()
                 )
         )
@@ -552,11 +562,11 @@ class OpenApi3GeneratorTest {
         )
     }
 
-    private fun getProductRequestWithDifferentParameter(): RequestModel {
+    private fun getProductRequestWithDifferentParameter(name: String, description: String): RequestModel {
         return getProductRequest().copy(requestParameters = listOf(
                 ParameterDescriptor(
-                        name = "color",
-                        description = "Changes the color of the product",
+                        name = name,
+                        description = description,
                         type = "STRING",
                         optional = true,
                         ignored = false


### PR DESCRIPTION
The OpenAPI 2 / 3 Generators will now document all request / path / header parameters which are found for a request with the same path and method. 

If a parameter is documented multiple times, the documentation of the first request will be used. 