### PR TITLE
remove jitpack requirement

### DIFF
--- a/restdocs-api-spec-gradle-plugin/build.gradle.kts
+++ b/restdocs-api-spec-gradle-plugin/build.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.serialization.js.DynamicTypeDeserializer.id
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 

--- a/restdocs-api-spec-jsonschema/build.gradle.kts
+++ b/restdocs-api-spec-jsonschema/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val jacksonVersion: String by extra
@@ -16,7 +15,7 @@ val junitVersion: String by extra
 dependencies {
     compile(kotlin("stdlib-jdk8"))
     compile(project(":restdocs-api-spec-model"))
-    compile("com.github.everit-org.json-schema:org.everit.json.schema:1.9.1")
+    compile("com.github.erosb:everit-json-schema:1.11.0")
     compile("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 

--- a/restdocs-api-spec-mockmvc/build.gradle.kts
+++ b/restdocs-api-spec-mockmvc/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val springBootVersion: String by extra

--- a/restdocs-api-spec-model/build.gradle.kts
+++ b/restdocs-api-spec-model/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 dependencies {

--- a/restdocs-api-spec-openapi-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val junitVersion: String by extra

--- a/restdocs-api-spec-openapi3-generator/build.gradle.kts
+++ b/restdocs-api-spec-openapi3-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val jacksonVersion: String by extra

--- a/restdocs-api-spec-postman-generator/build.gradle.kts
+++ b/restdocs-api-spec-postman-generator/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 repositories {
     mavenCentral()
     jcenter()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val junitVersion: String by extra

--- a/restdocs-api-spec-restassured/build.gradle.kts
+++ b/restdocs-api-spec-restassured/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 repositories {
     mavenCentral()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val springBootVersion: String by extra

--- a/restdocs-api-spec/build.gradle.kts
+++ b/restdocs-api-spec/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 }
 repositories {
     mavenCentral()
-    maven { url = uri("https://jitpack.io") }
 }
 
 val jacksonVersion: String by extra
@@ -32,7 +31,7 @@ dependencies {
     testCompile("com.jayway.jsonpath:json-path:2.3.0")
 
     testImplementation("com.github.java-json-tools:json-schema-validator:2.2.10")
-    testImplementation("com.github.everit-org.json-schema:org.everit.json.schema:1.9.1")
+    testImplementation("com.github.erosb:everit-json-schema:1.11.0")
 }
 
 


### PR DESCRIPTION
The only reason we need the Jitpack repository at this point if for the json-schema package and newer versions of that package are available in maven central.  This change should remove the Jitpack requirement which should allow restdocs-api-spec to be pushed to maven central.  This will also allow me to push restdocs-spec-maven-plugin to maven central as well which is important for a lot of maven users.