### PR TITLE
Publish plugin to the Gradle Plugins Portal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ cache:
 install: true
 script: "./gradlew clean build coveralls"
 deploy:
-  provider: script
-  script: "./gradlew binTrayUpload"
-  on:
-    tags: true
+  - provider: script
+    script: "./gradlew binTrayUpload"
+    on:
+      tags: true
+  - provider: script
+    script: "./gradlew publishPlugins -p restdocs-api-spec-gradle-plugin"
+    on:
+      tags: true
 env:
   global:
   - CI_NAME=travis-ci

--- a/README.md
+++ b/README.md
@@ -84,63 +84,71 @@ The [ResourceSnippet](restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apis
 
 #### Gradle
 
-```groovy
-buildscript {
-    repositories {
-    //..
-        jcenter() //1
+1. Add the plugin
+    * Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+        ```groovy
+        plugins {
+            id 'com.epages.restdocs-api-spec' version '0.9.5'
+        }
+        ```
+        Examples with Kotlin are also available [here](https://plugins.gradle.org/plugin/com.epages.restdocs-api-spec)
+    * __OR__ Using [legacy plugin application](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
+        * *1.1* Use of `buildscript` requires you to add `jcenter` repositories to `buildscript` to resolve the `restdocs-api-spec-gradle-plugin`.
+        * *1.2* add the dependency to `restdocs-api-spec-gradle-plugin`
+        * *1.3* apply `restdocs-api-spec-gradle-plugin`
+        ```groovy
+        buildscript {
+            repositories {
+                jcenter() //1.1
+            }
+            dependencies {
+                classpath('com.epages:restdocs-api-spec-gradle-plugin:0.9.5') //1.2
+            }
+        }
+  
+        apply plugin: 'com.epages.restdocs-api-spec' //1.3
+        
+        ```
+2. Add required dependencies to your tests
+    * *2.1* add the `jcenter` repository used to resolve the `com.epages:restdocs-api-spec` module of the project.
+    * *2.2* add the actual `restdocs-api-spec-mockmvc` dependency to the test scope. Use `restdocs-api-spec-restassured` if you use `RestAssured` instead of `MockMvc`.
+    * *2.3* add configuration options for restdocs-api-spec-gradle-plugin`. See [Gradle plugin configuration](#gradle-plugin-configuration) 
+    ```groovy
+    
+    repositories { //2.1
+        jcenter()
     }
+    
     dependencies {
         //..
-        classpath("com.epages:restdocs-api-spec-gradle-plugin:0.9.5") //2
+        testCompile('com.epages:restdocs-api-spec-mockmvc:0.9.5') //2.2
     }
-}
-//..
-apply plugin: 'com.epages.restdocs-api-spec' //3
-
-repositories { //4
-    jcenter()
-}
-
-//..
-
-dependencies {
-    //..
-    testCompile('com.epages:restdocs-api-spec-mockmvc:0.9.5') //5
-}
-
-openapi { //6
-    host = 'localhost:8080'
-    basePath = '/api'
-    title = 'My API'
-    description = 'My API description'
-    tagDescriptionsPropertiesFile = 'src/docs/tag-descriptions.yaml'
-    version = '1.0.0'
-    format = 'json'
-}
-
-openapi3 {
-	server = 'https://localhost:8080'
-	title = 'My API'
-	description = 'My API description'
-	tagDescriptionsPropertiesFile = 'src/docs/tag-descriptions.yaml'
-	version = '0.1.0'
-	format = 'yaml'
-}
-
-postman {
-    title = 'My API'
-    version = '0.1.0'
-    baseUrl = 'https://localhost:8080'
-}
-```
-
-1. add `jcenter` repositories to `buildscript` to resolve the `restdocs-api-spec-gradle-plugin`.
-2. add the dependency to `restdocs-api-spec-gradle-plugin`
-3. apply `restdocs-api-spec-gradle-plugin`
-4. add the `jcenter` repository used to resolve the `com.epages:restdocs-api-spec` module of the project.
-5. add the actual `restdocs-api-spec-mockmvc` dependency to the test scope. Use `restdocs-api-spec-restassured` if you use `RestAssured` instead of `MockMvc`.
-6. add configuration options for restdocs-api-spec-gradle-plugin`. See [Gradle plugin configuration](#gradle-plugin-configuration)
+    
+    openapi { //2.3
+        host = 'localhost:8080'
+        basePath = '/api'
+        title = 'My API'
+        description = 'My API description'
+        tagDescriptionsPropertiesFile = 'src/docs/tag-descriptions.yaml'
+        version = '1.0.0'
+        format = 'json'
+    }
+    
+    openapi3 {
+        server = 'https://localhost:8080'
+        title = 'My API'
+        description = 'My API description'
+        tagDescriptionsPropertiesFile = 'src/docs/tag-descriptions.yaml'
+        version = '0.1.0'
+        format = 'yaml'
+    }
+    
+    postman {
+        title = 'My API'
+        version = '0.1.0'
+        baseUrl = 'https://localhost:8080'
+    }
+    ```
 
 See the [build.gradle](samples/restdocs-api-spec-sample/build.gradle) for the setup used in the sample project.
 

--- a/restdocs-api-spec-gradle-plugin/build.gradle.kts
+++ b/restdocs-api-spec-gradle-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `kotlin-dsl`
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.12.0"
 }
 
 gradlePlugin {

--- a/restdocs-api-spec-gradle-plugin/build.gradle.kts
+++ b/restdocs-api-spec-gradle-plugin/build.gradle.kts
@@ -22,13 +22,13 @@ gradlePlugin {
 
 pluginBundle {
     website = "https://github.com/ePages-de/restdocs-api-spec"
-    vcsUrl = "git@github.com:ePages-de/restdocs-api-spec.git"
-    tags = listOf("ePages", "Spring", "RestDocs", "Gradle", "plugin", "openapi", "openapi3", "postman", "api", "specification")
+    vcsUrl = "https://github.com/ePages-de/restdocs-api-spec"
+    tags = listOf("spring", "restdocs", "openapi", "openapi3", "postman", "api", "specification")
     description = "Extends Spring REST Docs with API specifications in OpenAPI2, OpenAPI3 and Postman Collections formats"
 
     (plugins) {
         "com.epages.restdocs-api-spec" {
-            displayName = "ePages Spring RestDocs API Spec Gradle Plugin"
+            displayName = "restdocs-api-spec gradle plugin"
         }
     }
 

--- a/restdocs-api-spec-gradle-plugin/build.gradle.kts
+++ b/restdocs-api-spec-gradle-plugin/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     kotlin("jvm")
     `java-gradle-plugin`
     `kotlin-dsl`
+    id("com.gradle.plugin-publish") version "0.10.1"
 }
 
 gradlePlugin {
@@ -18,6 +19,25 @@ gradlePlugin {
         }
     }
 }
+
+pluginBundle {
+    website = "https://github.com/ePages-de/restdocs-api-spec"
+    vcsUrl = "git@github.com:ePages-de/restdocs-api-spec.git"
+    tags = listOf("ePages", "Spring", "RestDocs", "Gradle", "plugin", "openapi", "openapi3", "postman", "api", "specification")
+    description = "Extends Spring REST Docs with API specifications in OpenAPI2, OpenAPI3 and Postman Collections formats"
+
+    (plugins) {
+        "com.epages.restdocs-api-spec" {
+            displayName = "ePages Spring RestDocs API Spec Gradle Plugin"
+        }
+    }
+
+    mavenCoordinates {
+        groupId = "com.epages"
+        artifactId = "restdocs-api-spec-gradle-plugin"
+    }
+}
+
 
 val jacksonVersion: String by extra
 val junitVersion: String by extra


### PR DESCRIPTION
**Motivation**

Use of the plugins DSL is much more concise and seems to be the way forward for Gradle. With the removal of need for Jitpack in #77 this appears to be easier now.

Resolves #36.

**Changes made**
* Followed guide [here](https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/) and [here](https://plugins.gradle.org/docs/publish-plugin) to add the requisite metadata into the plugin.
* Included `mavenCoordinates` as my reading indicates we might need this since the plugin is already being published to bintray
* Added an additional deployment into the Travis build
* Updated the README to indicate how to use either approach

**For team to do**
* Register with https://plugins.gradle.org/user/register
* Get API keys into Travis
* If you could possibly publish an RC build (e.g. `0.9.1-rc1`) I can help test it. I initially updated the samples too; but probably better to have a build published first before we do that.