### PR TITLE
Correctly handle ignored parameters

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
@@ -83,7 +83,7 @@ internal object DescriptorValidator {
     private fun toParameterDescriptors(parameters: List<ParameterDescriptorWithType>) =
         parameters.map { p -> parameterWithName(p.name).description(p.description)
             .apply { if (p.optional) optional() }
-            .apply { if (p.isIgnored) optional() }
+            .apply { if (p.isIgnored) ignored() }
         }
 
     private fun toHeaderDescriptors(requestHeaders: List<HeaderDescriptorWithType>) =


### PR DESCRIPTION
Ignored and optional parameters were treated equally, which is probably not the correct behavior. Due to missing tests for `DescriptorValidator` I did not add or change existing tests.