### PR TITLE
Loosen isJWT check.

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/JwtSecurityHandler.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/JwtSecurityHandler.kt
@@ -39,8 +39,8 @@ internal class JwtSecurityHandler : SecurityRequirementsExtractor {
             val jwtHeader = jwtParts[0]
             val decodedJwtHeader = String(Base64.getDecoder().decode(jwtHeader))
             try {
-                val jwtMap = ObjectMapper().readValue<Map<String, Any>>(decodedJwtHeader)
-                return jwtMap["typ"] == "JWT"
+                return ObjectMapper().readValue<Map<String, Any>>(decodedJwtHeader)
+                        .containsKey("alg")
             } catch (e: IOException) {
                 // probably not JWT
             }

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/JwtSecurityHandlerTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/JwtSecurityHandlerTest.kt
@@ -76,7 +76,8 @@ class JwtSecurityHandlerTest {
         operation = OperationBuilder().request("/some")
             .header(
                 AUTHORIZATION,
-                "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+                // this jwt token doesn't contain typ header but is still valid format
+                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ"
             )
             .build()
     }


### PR DESCRIPTION
Sorry I think I made a mistake in previous PR: https://github.com/ePages-de/restdocs-api-spec/pull/86

The check [`isJWT`](https://github.com/ePages-de/restdocs-api-spec/pull/86/files#diff-68ef922206998a37fe01437ae83cb07eR36) is too strict. According to spec: https://tools.ietf.org/html/rfc7519#section-5.1 `typ` header isn't even required, and its value may not be "JWT". `alg` on the other hand is more
commonly used. So checking its existence is much more reliable.