### PR TITLE
Add wrapper for webflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,78 +302,37 @@ RestAssured.given(this.spec)
 
 #### WebTestClient based tests
 
-We've now added a convenience wrapper similar to `MockMvcRestDocumentationWrapper` for WebTestClient.
+We also offer a convenience wrapper for `WebTestClient` which works similar to `MockMvcRestDocumentationWrapper`.
 The usage is similar to MockMVC, except that [com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper](restdocs-api-spec-webtestclient/src/main/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapper.kt) is used instead of [com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper](restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt).
 
 To use the `WebTestClientRestDocumentationWrapper`, you will have to add a dependency to [restdocs-api-spec-webtestclient](restdocs-api-spec-webtestclient) to your build.
+
 ```
-    import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-    import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-    import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-    import static org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.documentationConfiguration;
-    
-    import org.junit.jupiter.api.BeforeEach;
-    import org.junit.jupiter.api.Test;
-    import org.junit.jupiter.api.extension.ExtendWith;
-    import org.springframework.boot.test.context.SpringBootTest;
-    import org.springframework.context.ApplicationContext;
-    import org.springframework.http.HttpHeaders;
-    import org.springframework.http.MediaType;
-    import org.springframework.restdocs.RestDocumentationContextProvider;
-    import org.springframework.restdocs.RestDocumentationExtension;
-    import org.springframework.restdocs.headers.HeaderDocumentation;
-    import org.springframework.restdocs.payload.JsonFieldType;
-    import org.springframework.restdocs.payload.PayloadDocumentation;
-    import org.springframework.restdocs.request.RequestDocumentation;
-    import org.springframework.test.context.junit.jupiter.SpringExtension;
-    import org.springframework.test.web.reactive.server.WebTestClient;
-    
-    import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper;
-    
-    @SpringBootTest
-    @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
-    public class SampleTest {
-    
-      private WebTestClient webTestClient;
-    
-      @BeforeEach
-      void setUp(RestDocumentationContextProvider restDocumentation,
-          ApplicationContext context) {
-        this.webTestClient = WebTestClient.bindToApplicationContext(context)
-            .configureClient()
-            .filter(documentationConfiguration(restDocumentation))
-            .build();
-      }
-    
-      @Test
-      void sample() {
-        this.webTestClient.get().uri("/sample/{id}?queryParam=something", "1024").exchange()
-            .expectStatus().isOk().expectBody()
-            .consumeWith(
-                WebTestClientRestDocumentationWrapper
-                    .document("sample",
-                        RequestDocumentation.pathParameters(
-                            parameterWithName("id").description(
-                                "description of the path parameter")
-                        ),
-                        RequestDocumentation.requestParameters(
-                            parameterWithName("queryParam").description(
-                                "description of the query parameter")
-                        ),
-                        HeaderDocumentation.responseHeaders(
-                            headerWithName(HttpHeaders.CONTENT_TYPE)
-                                .description(MediaType.APPLICATION_JSON_UTF8_VALUE)
-                        ),
-                        responseFields(
-                            PayloadDocumentation.fieldWithPath("field1").type(JsonFieldType.STRING)
-                                .description("description of field1"),
-                            PayloadDocumentation.fieldWithPath("field2").type(JsonFieldType.STRING)
-                                .description("description of field2")
-                        )
-                    )
-            );
-      }
-    }
+webTestClient.get().uri("/sample/{id}?queryParam=something", "1024").exchange()
+    .expectStatus().isOk().expectBody()
+    .consumeWith(
+        WebTestClientRestDocumentationWrapper
+            .document("sample",
+                RequestDocumentation.pathParameters(
+                    parameterWithName("id").description(
+                        "description of the path parameter")
+                ),
+                RequestDocumentation.requestParameters(
+                    parameterWithName("queryParam").description(
+                        "description of the query parameter")
+                ),
+                HeaderDocumentation.responseHeaders(
+                    headerWithName(HttpHeaders.CONTENT_TYPE)
+                        .description(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                ),
+                responseFields(
+                    PayloadDocumentation.fieldWithPath("field1").type(JsonFieldType.STRING)
+                        .description("description of field1"),
+                    PayloadDocumentation.fieldWithPath("field2").type(JsonFieldType.STRING)
+                        .description("description of field2")
+                )
+            )
+    );
 ```
 
 ### Security Definitions in OpenAPI

--- a/restdocs-api-spec-webtestclient/build.gradle.kts
+++ b/restdocs-api-spec-webtestclient/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+}
+
+val springBootVersion: String by extra
+val springRestDocsVersion: String by extra
+val junitVersion: String by extra
+
+dependencies {
+    compile(kotlin("stdlib-jdk8"))
+
+    compile(project(":restdocs-api-spec"))
+    compile("org.springframework.restdocs:spring-restdocs-webtestclient:$springRestDocsVersion")
+
+    testCompile("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {
+        exclude("junit")
+    }
+    testCompile("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testImplementation("org.junit-pioneer:junit-pioneer:0.2.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-web:$springBootVersion")
+    testCompile("org.springframework.boot:spring-boot-starter-hateoas:$springBootVersion")
+    testImplementation("io.projectreactor:reactor-core:3.2.8.RELEASE")
+}
+

--- a/restdocs-api-spec-webtestclient/src/main/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-webtestclient/src/main/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapper.kt
@@ -1,0 +1,97 @@
+package com.epages.restdocs.apispec
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor
+import org.springframework.restdocs.snippet.Snippet
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation
+import org.springframework.test.web.reactive.server.EntityExchangeResult
+import java.util.function.Consumer
+import java.util.function.Function
+
+object WebTestClientRestDocumentationWrapper : RestDocumentationWrapper() {
+
+    @JvmOverloads
+    @JvmStatic
+    fun <T> document(
+        identifier: String,
+        resourceDetails: ResourceSnippetDetails,
+        requestPreprocessor: OperationRequestPreprocessor? = null,
+        responsePreprocessor: OperationResponsePreprocessor? = null,
+        snippetFilter: Function<List<Snippet>, List<Snippet>> = Function.identity(),
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+
+        val enhancedSnippets =
+                enhanceSnippetsWithResourceSnippet(
+                        resourceDetails = resourceDetails,
+                        snippetFilter = snippetFilter,
+                        snippets = *snippets
+                )
+
+        if (requestPreprocessor != null && responsePreprocessor != null) {
+            return WebTestClientRestDocumentation.document(
+                    identifier,
+                    requestPreprocessor,
+                    responsePreprocessor,
+                    *enhancedSnippets
+            )
+        } else if (requestPreprocessor != null) {
+            return WebTestClientRestDocumentation.document(identifier, requestPreprocessor, *enhancedSnippets)
+        } else if (responsePreprocessor != null) {
+            return WebTestClientRestDocumentation.document(identifier, responsePreprocessor, *enhancedSnippets)
+        }
+
+        return WebTestClientRestDocumentation.document(identifier, *enhancedSnippets)
+    }
+
+    @JvmOverloads
+    @JvmStatic
+    fun <T> document(
+        identifier: String,
+        description: String? = null,
+        summary: String? = null,
+        privateResource: Boolean = false,
+        deprecated: Boolean = false,
+        requestPreprocessor: OperationRequestPreprocessor? = null,
+        responsePreprocessor: OperationResponsePreprocessor? = null,
+        snippetFilter: Function<List<Snippet>, List<Snippet>> = Function.identity(),
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+        return document(
+                identifier = identifier,
+                resourceDetails = resourceDetails()
+                        .description(description)
+                        .summary(summary)
+                        .privateResource(privateResource)
+                        .deprecated(deprecated),
+                requestPreprocessor = requestPreprocessor,
+                responsePreprocessor = responsePreprocessor,
+                snippetFilter = snippetFilter,
+                snippets = *snippets
+        )
+    }
+
+    @JvmStatic
+    fun <T> document(
+        identifier: String,
+        requestPreprocessor: OperationRequestPreprocessor,
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+        return document(identifier, null, null, false, false, requestPreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
+    fun <T> document(
+        identifier: String,
+        description: String,
+        privateResource: Boolean,
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+        return document(identifier, description, null, privateResource, snippets = *snippets)
+    }
+
+    @JvmStatic
+    fun resourceDetails(): ResourceSnippetDetails {
+        return ResourceSnippetParametersBuilder()
+    }
+}

--- a/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetIntegrationTest.kt
+++ b/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetIntegrationTest.kt
@@ -1,0 +1,131 @@
+package com.epages.restdocs.apispec
+
+import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import org.hibernate.validator.constraints.Length
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.hateoas.MediaTypes.HAL_JSON_VALUE
+import org.springframework.http.HttpHeaders.ACCEPT
+import org.springframework.http.HttpHeaders.CONTENT_TYPE
+import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+import javax.validation.constraints.NotEmpty
+
+@ExtendWith(SpringExtension::class)
+@AutoConfigureRestDocs
+open class ResourceSnippetIntegrationTest {
+
+    val operationName = "test-${System.currentTimeMillis()}"
+
+    lateinit var bodyContentSpec: WebTestClient.BodyContentSpec
+
+    @SpringBootApplication
+    open class TestApplication {
+        lateinit var applicationContext: ConfigurableApplicationContext
+        fun main(args: Array<String>) {
+            applicationContext = SpringApplication.run(TestApplication::class.java, *args)
+        }
+
+        @RestController
+        internal open class TestController {
+
+            @PostMapping(path = ["/some/{someId}/other/{otherId}"])
+            fun doSomething(
+                @PathVariable someId: String,
+                @PathVariable otherId: Int?,
+                @RequestHeader("X-Custom-Header") customHeader: String,
+                @RequestBody testDataHolder: TestDataHolder,
+                serverHttpRequest: ServerHttpRequest
+            ): ResponseEntity<TestDataHolder> {
+                val responseData = testDataHolder.copy(id = UUID.randomUUID().toString())
+
+                // temporary hack until spring hateoas supports webflux officially.
+                val links = ArrayList<Link>()
+                links.add(Link(serverHttpRequest.uri.toString()))
+                links.add(Link(serverHttpRequest.uri.toString()))
+                val linksHolder = LinksHolder(Link(serverHttpRequest.uri.toString()), links)
+                responseData._links = linksHolder
+
+                return ResponseEntity
+                        .ok()
+                        .header("X-Custom-Header", customHeader)
+                        .header("Content-Type", HAL_JSON_VALUE)
+                        .body(responseData)
+            }
+        }
+    }
+
+    internal data class Link(
+        val href: String
+    )
+
+    internal data class LinksHolder(
+        var self: Link,
+        var multiple: List<Link>
+    )
+
+    internal data class TestDataHolder(
+        @field:Length(min = 1, max = 255)
+        val comment: String? = null,
+        val flag: Boolean = false,
+        val count: Int = 0,
+        @field:NotEmpty
+        val id: String? = null,
+        var _links: LinksHolder? = null
+    ) {
+        constructor(comment: String, flag: Boolean, count: Int, id: String) : this(comment, flag, count, id, null)
+    }
+}
+
+fun fieldDescriptors(): FieldDescriptors {
+    val fields = ConstrainedFields(ResourceSnippetIntegrationTest.TestDataHolder::class.java)
+    return ResourceDocumentation.fields(
+            fields.withPath("comment").description("the comment").optional(),
+            fields.withPath("flag").description("the flag"),
+            fields.withMappedPath("count", "count").description("the count")
+    )
+}
+
+fun buildFullResourceSnippet(): ResourceSnippet {
+    return resource(
+            ResourceSnippetParameters.builder()
+                    .description("description")
+                    .summary("summary")
+                    .deprecated(true)
+                    .privateResource(true)
+                    .requestFields(fieldDescriptors())
+                    .responseFields(fieldDescriptors().and(fieldWithPath("id").description("id")))
+                    .requestHeaders(
+                            headerWithName("X-Custom-Header").description("A custom header"),
+                            headerWithName(ACCEPT).description("Accept")
+                    )
+                    .responseHeaders(
+                            headerWithName("X-Custom-Header").description("A custom header"),
+                            headerWithName(CONTENT_TYPE).description("ContentType")
+                    )
+                    .pathParameters(
+                            parameterWithName("someId").description("some id"),
+                            parameterWithName("otherId").description("otherId id").type(SimpleType.INTEGER)
+                    )
+                    .links(
+                            linkWithRel("self").description("some"),
+                            linkWithRel("multiple").description("multiple")
+                    )
+                    .build()
+    )
+}

--- a/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
+++ b/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
@@ -1,0 +1,279 @@
+package com.epages.restdocs.apispec
+
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
+import org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation.links
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.restdocs.webtestclient.WebTestClientRestDocumentation.document
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.io.File
+
+@ExtendWith(SpringExtension::class)
+@WebFluxTest
+class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTestClient: WebTestClient) : ResourceSnippetIntegrationTest() {
+
+    @Test
+    fun should_document_both_restdocs_and_resource() {
+        givenEndpointInvoked()
+
+        whenDocumentedWithRestdocsAndResource()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_both_restdocs_and_resource_as_private_resource() {
+        givenEndpointInvoked()
+
+        whenDocumentedAsPrivateResource()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_using_the_passed_raml_snippet() {
+        givenEndpointInvoked()
+
+        whenDocumentedWithRamlSnippet()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_value_ignored_fields_and_links() {
+        givenEndpointInvoked()
+
+        assertThatCode { this.whenDocumentedWithAllFieldsLinksIgnored() }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun should_document_restdocs_and_resource_snippet_details() {
+        givenEndpointInvoked()
+
+        whenDocumentedWithResourceSnippetDetails()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_request() {
+        givenEndpointInvoked()
+
+        whenResourceSnippetDocumentedWithoutParameters()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_request_with_description() {
+        givenEndpointInvoked()
+
+        whenResourceSnippetDocumentedWithDescription()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_request_with_fields() {
+        givenEndpointInvoked()
+
+        whenResourceSnippetDocumentedWithRequestAndResponseFields()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
+    fun should_document_request_with_null_field() {
+        givenEndpointInvoked("null")
+
+        assertThatCode { this.whenResourceSnippetDocumentedWithRequestAndResponseFields() }
+                .doesNotThrowAnyException()
+    }
+
+    private fun whenResourceSnippetDocumentedWithoutParameters() {
+        bodyContentSpec
+                .consumeWith(document(operationName, resource()))
+    }
+
+    private fun whenResourceSnippetDocumentedWithDescription() {
+        bodyContentSpec
+                .consumeWith(document(operationName, resource("A description")))
+    }
+
+    private fun whenResourceSnippetDocumentedWithRequestAndResponseFields() {
+        bodyContentSpec
+                .consumeWith(document(operationName, buildFullResourceSnippet()))
+    }
+
+    private fun givenEndpointInvoked(flagValue: String = "true") {
+
+        bodyContentSpec = webTestClient.post()
+                .uri("/some/{someId}/other/{otherId}", "id", 1)
+                .contentType(APPLICATION_JSON)
+                .header("X-Custom-Header", "test")
+                .accept(APPLICATION_JSON)
+                .syncBody("""{
+                            "comment": "some",
+                            "flag": $flagValue,
+                            "count": 1
+                        }""".trimIndent()
+                )
+                .exchange()
+                .expectStatus().isOk
+                .expectBody()
+    }
+
+    private fun thenSnippetFileExists() {
+        with(generatedSnippetFile()) {
+            then(this).exists()
+            val contents = readText()
+            then(contents).isNotEmpty()
+        }
+    }
+
+    private fun generatedSnippetFile() = File("build/generated-snippets", "$operationName/resource.json")
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithRestdocsAndResource() {
+        bodyContentSpec
+                .consumeWith { print(it) }
+                .consumeWith(
+                        WebTestClientRestDocumentationWrapper.document(
+                                identifier = operationName,
+                                snippets = *arrayOf(
+                                        pathParameters(
+                                                parameterWithName("someId").description("someId"),
+                                                parameterWithName("otherId").description("otherId")
+                                        ),
+                                        requestFields(fieldDescriptors().fieldDescriptors),
+                                        requestHeaders(
+                                                headerWithName("X-Custom-Header").description("some custom header")
+                                        ),
+                                        responseFields(
+                                                fieldWithPath("comment").description("the comment"),
+                                                fieldWithPath("flag").description("the flag"),
+                                                fieldWithPath("count").description("the count"),
+                                                fieldWithPath("id").description("id"),
+                                                subsectionWithPath("_links").ignored()
+                                        ),
+                                        responseHeaders(
+                                                headerWithName("X-Custom-Header").description("some custom header")
+                                        ),
+                                        links(
+                                                linkWithRel("self").description("some"),
+                                                linkWithRel("multiple").description("multiple")
+                                        )
+                                )
+                        )
+                )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithRamlSnippet() {
+        bodyContentSpec
+                .consumeWith(
+                        WebTestClientRestDocumentationWrapper.document(
+                                identifier = operationName,
+                                snippets = *arrayOf(buildFullResourceSnippet())
+                        )
+                )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithAllFieldsLinksIgnored() {
+        bodyContentSpec
+                .consumeWith(
+                        WebTestClientRestDocumentationWrapper.document(
+                                identifier = operationName,
+                                snippets = *arrayOf(
+                                        requestFields(fieldDescriptors().fieldDescriptors),
+                                        responseFields(
+                                                fieldWithPath("comment").ignored(),
+                                                fieldWithPath("flag").ignored(),
+                                                fieldWithPath("count").ignored(),
+                                                fieldWithPath("id").ignored(),
+                                                subsectionWithPath("_links").ignored()
+                                        ),
+                                        links(
+                                                linkWithRel("self").optional().ignored(),
+                                                linkWithRel("multiple").optional().ignored()
+                                        )
+                                )
+                        )
+                )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedAsPrivateResource() {
+        val operationRequestPreprocessor = OperationRequestPreprocessor { r -> r }
+        bodyContentSpec
+                .consumeWith(
+                        WebTestClientRestDocumentationWrapper.document(
+                                identifier = operationName,
+                                privateResource = true,
+                                requestPreprocessor = operationRequestPreprocessor,
+                                snippets = *arrayOf(
+                                        requestFields(fieldDescriptors().fieldDescriptors),
+                                        responseFields(
+                                                fieldWithPath("comment").description("the comment"),
+                                                fieldWithPath("flag").description("the flag"),
+                                                fieldWithPath("count").description("the count"),
+                                                fieldWithPath("id").description("id"),
+                                                subsectionWithPath("_links").ignored()
+                                        ),
+                                        links(
+                                                linkWithRel("self").description("some"),
+                                                linkWithRel("multiple").description("multiple")
+                                        )
+                                )
+                        )
+                )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithResourceSnippetDetails() {
+        val operationRequestPreprocessor = OperationRequestPreprocessor { r -> r }
+        bodyContentSpec
+                .consumeWith(
+                        WebTestClientRestDocumentationWrapper.document(
+                                identifier = operationName,
+                                resourceDetails = WebTestClientRestDocumentationWrapper.resourceDetails()
+                                        .description("The Resource")
+                                        .privateResource(true)
+                                        .tag("some-tag"),
+                                requestPreprocessor = operationRequestPreprocessor,
+                                snippets = *arrayOf(
+                                        requestFields(fieldDescriptors().fieldDescriptors),
+                                        responseFields(
+                                                fieldWithPath("comment").description("the comment"),
+                                                fieldWithPath("flag").description("the flag"),
+                                                fieldWithPath("count").description("the count"),
+                                                fieldWithPath("id").description("id"),
+                                                subsectionWithPath("_links").ignored()
+                                        ),
+                                        links(
+                                                linkWithRel("self").description("some"),
+                                                linkWithRel("multiple").description("multiple")
+                                        )
+                                )
+                        )
+                )
+    }
+}

--- a/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
+++ b/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
@@ -150,7 +150,6 @@ class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTes
 
     private fun generatedSnippetFile() = File("build/generated-snippets", "$operationName/resource.json")
 
-    @Throws(Exception::class)
     private fun whenDocumentedWithRestdocsAndResource() {
         bodyContentSpec
                 .consumeWith { print(it) }
@@ -185,7 +184,6 @@ class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTes
                 )
     }
 
-    @Throws(Exception::class)
     private fun whenDocumentedWithRamlSnippet() {
         bodyContentSpec
                 .consumeWith(

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,3 +12,4 @@ project(':restdocs-api-spec-sample-web-test-client').projectDir = file('samples/
 include 'restdocs-api-spec-mockmvc'
 include 'restdocs-api-spec-restassured'
 include 'restdocs-api-spec-postman-generator'
+include 'restdocs-api-spec-webtestclient'


### PR DESCRIPTION
Add a `WebTestClientRestDocumentationWrapper` for Webflux.
Had to add custom hypermedia info for the integration test as `spring-hateoas` has not released their update with webflux support yet. 
Plan to update the test when they do, but for now it validates all that is required,.