### PR TITLE
Add convenient methods to match Spring Rest Docs base WebTestClientRestDocumentation

### DIFF
--- a/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
@@ -91,7 +91,6 @@ object MockMvcRestDocumentationWrapper : RestDocumentationWrapper() {
         return document(identifier, description, null, privateResource, snippets = *snippets)
     }
 
-
     @JvmStatic
     fun document(
         identifier: String,

--- a/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
@@ -91,6 +91,26 @@ object MockMvcRestDocumentationWrapper : RestDocumentationWrapper() {
         return document(identifier, description, null, privateResource, snippets = *snippets)
     }
 
+
+    @JvmStatic
+    fun document(
+        identifier: String,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): RestDocumentationResultHandler {
+        return document(identifier, null, null, false, false, responsePreprocessor = responsePreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
+    fun document(
+        identifier: String,
+        requestPreprocessor: OperationRequestPreprocessor,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): RestDocumentationResultHandler {
+        return document(identifier, null, null, false, false, requestPreprocessor, responsePreprocessor, snippets = *snippets)
+    }
+
     @JvmStatic
     fun resourceDetails(): ResourceSnippetDetails {
         return ResourceSnippetParametersBuilder()

--- a/restdocs-api-spec-restassured/src/main/kotlin/com/epages/restdocs/apispec/RestAssuredRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-restassured/src/main/kotlin/com/epages/restdocs/apispec/RestAssuredRestDocumentationWrapper.kt
@@ -92,6 +92,25 @@ object RestAssuredRestDocumentationWrapper : RestDocumentationWrapper() {
     }
 
     @JvmStatic
+    fun document(
+        identifier: String,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): RestDocumentationFilter {
+        return document(identifier, null, null, false, false, responsePreprocessor = responsePreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
+    fun document(
+        identifier: String,
+        requestPreprocessor: OperationRequestPreprocessor,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): RestDocumentationFilter {
+        return document(identifier, null, null, false, false, requestPreprocessor, responsePreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
     fun resourceDetails(): ResourceSnippetDetails {
         return ResourceSnippetParametersBuilder()
     }

--- a/restdocs-api-spec-webtestclient/src/main/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-webtestclient/src/main/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapper.kt
@@ -91,6 +91,25 @@ object WebTestClientRestDocumentationWrapper : RestDocumentationWrapper() {
     }
 
     @JvmStatic
+    fun <T> document(
+        identifier: String,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+        return document(identifier, null, null, false, false, responsePreprocessor = responsePreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
+    fun <T> document(
+        identifier: String,
+        requestPreprocessor: OperationRequestPreprocessor,
+        responsePreprocessor: OperationResponsePreprocessor,
+        vararg snippets: Snippet
+    ): Consumer<EntityExchangeResult<T>> {
+        return document(identifier, null, null, false, false, requestPreprocessor, responsePreprocessor, snippets = *snippets)
+    }
+
+    @JvmStatic
     fun resourceDetails(): ResourceSnippetDetails {
         return ResourceSnippetParametersBuilder()
     }


### PR DESCRIPTION
Adding couple methods to ease endpoint documentation for response and both request response pre-processor similarly to Spring RestDocs' [WebTestClientRestDocumentation](https://github.com/spring-projects/spring-restdocs/blob/619847582a1c69b7db92b3791d43268f981fb805/spring-restdocs-webtestclient/src/main/java/org/springframework/restdocs/webtestclient/WebTestClientRestDocumentation.java#L112)