### PR TITLE
Add support for constraints on nested fields.

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ConstrainedFields.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ConstrainedFields.kt
@@ -18,7 +18,7 @@ class ConstrainedFields(private val classHoldingConstraints: Class<*>) {
      * @param path json path of the field
      */
     fun withPath(path: String): FieldDescriptor =
-        withMappedPath(path, path)
+        withMappedPath(path, beanPropertyNameFromPath(path))
 
     /**
      *
@@ -38,7 +38,10 @@ class ConstrainedFields(private val classHoldingConstraints: Class<*>) {
                 .value(this.validatorConstraintResolver.resolveForProperty(beanPropertyName, classHoldingConstraints))
         )
 
+    private fun beanPropertyNameFromPath(jsonPath: String) = jsonPath.substringAfter(DOT_NOTATION_DELIMITER)
+
     companion object {
         private const val CONSTRAINTS_KEY = "validationConstraints"
+        private const val DOT_NOTATION_DELIMITER = "."
     }
 }

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ConstrainedFields.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ConstrainedFields.kt
@@ -38,7 +38,7 @@ class ConstrainedFields(private val classHoldingConstraints: Class<*>) {
                 .value(this.validatorConstraintResolver.resolveForProperty(beanPropertyName, classHoldingConstraints))
         )
 
-    private fun beanPropertyNameFromPath(jsonPath: String) = jsonPath.substringAfter(DOT_NOTATION_DELIMITER)
+    private fun beanPropertyNameFromPath(jsonPath: String) = jsonPath.substringAfterLast(DOT_NOTATION_DELIMITER)
 
     companion object {
         private const val CONSTRAINTS_KEY = "validationConstraints"

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
@@ -7,7 +7,6 @@ import javax.validation.constraints.NotEmpty
 
 internal class ConstrainedFieldsTest {
 
-
     @Test
     @Suppress("UNCHECKED_CAST")
     fun `should resolve constraints`() {

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
@@ -20,8 +20,8 @@ internal class ConstrainedFieldsTest {
 
     @Test
     @Suppress("UNCHECKED_CAST")
-    fun `should resolve nested constraints`() {
-        val fields = ConstrainedFields(SomeOtherWithConstraints::class.java)
+    fun `should resolve one level nested constraints`() {
+        val fields = ConstrainedFields(SomeWithConstraints::class.java)
         val descriptor = fields.withPath("nested.nonEmpty")
 
         then(descriptor.attributes).containsKey("validationConstraints")
@@ -29,15 +29,21 @@ internal class ConstrainedFieldsTest {
             .containsExactly(NotEmpty::class.java.name)
     }
 
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should resolve two level nested constraints`() {
+        val fields = ConstrainedFields(SomeWithConstraints::class.java)
+        val descriptor = fields.withPath("nested.nested.nonEmpty")
+
+        then(descriptor.attributes).containsKey("validationConstraints")
+        then((descriptor.attributes["validationConstraints"] as List<Constraint>).map { it.name })
+                .containsExactly(NotEmpty::class.java.name)
+    }
+
     private data class SomeWithConstraints(
         @field:NotEmpty
         val nonEmpty: String,
 
-        val nested: SomeOtherWithConstraints
-    )
-
-    private data class SomeOtherWithConstraints(
-        @field:NotEmpty
-        val nonEmpty: String
+        val nested: SomeWithConstraints?
     )
 }

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ConstrainedFieldsTest.kt
@@ -7,11 +7,11 @@ import javax.validation.constraints.NotEmpty
 
 internal class ConstrainedFieldsTest {
 
-    val fields = ConstrainedFields(SomeWithConstraints::class.java)
 
     @Test
     @Suppress("UNCHECKED_CAST")
     fun `should resolve constraints`() {
+        val fields = ConstrainedFields(SomeWithConstraints::class.java)
         val descriptor = fields.withPath("nonEmpty")
 
         then(descriptor.attributes).containsKey("validationConstraints")
@@ -19,7 +19,25 @@ internal class ConstrainedFieldsTest {
             .containsExactly(NotEmpty::class.java.name)
     }
 
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should resolve nested constraints`() {
+        val fields = ConstrainedFields(SomeOtherWithConstraints::class.java)
+        val descriptor = fields.withPath("nested.nonEmpty")
+
+        then(descriptor.attributes).containsKey("validationConstraints")
+        then((descriptor.attributes["validationConstraints"] as List<Constraint>).map { it.name })
+            .containsExactly(NotEmpty::class.java.name)
+    }
+
     private data class SomeWithConstraints(
+        @field:NotEmpty
+        val nonEmpty: String,
+
+        val nested: SomeOtherWithConstraints
+    )
+
+    private data class SomeOtherWithConstraints(
         @field:NotEmpty
         val nonEmpty: String
     )


### PR DESCRIPTION
Hi all,

I added support for constraints on nested fields.
The support has been implemented by simply choosing the last JSON path element as the bean property name:
someNestedObject.someField -> someField = bean property name
someField -> someField = bean property name