### PR TITLE
Add support for enum values in field descriptors.

### DIFF
--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -14,6 +14,7 @@ import org.everit.json.schema.EmptySchema
 import org.everit.json.schema.NullSchema
 import org.everit.json.schema.NumberSchema
 import org.everit.json.schema.ObjectSchema
+import org.everit.json.schema.EnumSchema
 import org.everit.json.schema.Schema
 import org.everit.json.schema.StringSchema
 import org.everit.json.schema.internal.JSONPrinter
@@ -242,6 +243,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
                 "string" -> StringSchema.builder()
                     .minLength(minLengthString(this))
                     .maxLength(maxLengthString(this))
+                "enum" -> EnumSchema.builder().possibleValues(this.attributes.enumValues)
                 else -> throw IllegalArgumentException("unknown field type $type")
             }
 

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -12,6 +12,7 @@ import org.everit.json.schema.ArraySchema
 import org.everit.json.schema.ObjectSchema
 import org.everit.json.schema.Schema
 import org.everit.json.schema.StringSchema
+import org.everit.json.schema.EnumSchema
 import org.everit.json.schema.ValidationException
 import org.everit.json.schema.loader.SchemaLoader
 import org.json.JSONArray
@@ -194,6 +195,20 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
         thenSchemaValidatesJson("""{ some: [ { "a": "b" } ] }""")
     }
 
+    @Test
+    fun should_generate_schema_for_enum_values() {
+        givenFieldDescriptorWithEnum()
+
+        whenSchemaGenerated()
+
+        then(schema).isInstanceOf(ObjectSchema::class.java)
+        val objectSchema = schema as ObjectSchema?
+        then(objectSchema!!.propertySchemas["some"]).isInstanceOf(EnumSchema::class.java)
+
+        thenSchemaIsValid()
+        thenSchemaValidatesJson("""{ some: "ENUM_VALUE_1" }""")
+    }
+
     private fun thenSchemaIsValid() {
 
         val report = JsonSchemaFactory.byDefault()
@@ -311,6 +326,15 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             ),
             FieldDescriptor("billingAddress.valid", "some", "BOOLEAN"),
             FieldDescriptor("paymentLineItem.lineItemTaxes", "some", "ARRAY")
+        )
+    }
+
+    private fun givenFieldDescriptorWithEnum() {
+        fieldDescriptors = listOf(
+                FieldDescriptor(
+                        "some",
+                        "some",
+                        "enum", attributes = Attributes(enumValues = listOf("ENUM_VALUE_1", "ENUM_VALUE_2")))
         )
     }
 

--- a/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
+++ b/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
@@ -80,7 +80,8 @@ open class FieldDescriptor(
 )
 
 data class Attributes(
-    val validationConstraints: List<Constraint> = emptyList()
+    val validationConstraints: List<Constraint> = emptyList(),
+    val enumValues: List<String> = emptyList()
 )
 
 data class Constraint(

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/EnumFields.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/EnumFields.kt
@@ -1,0 +1,37 @@
+package com.epages.restdocs.apispec
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.snippet.Attributes.key
+
+/**
+ * EnumFields can be used to add the possible enum values to a [FieldDescriptor]
+ * If these are present in the descriptor they are used to enrich the generated type information (e.g. JsonSchema)
+ */
+class EnumFields(enumType: Class<*>) {
+
+    private val possibleEnumValues: List<String>
+
+    init {
+        if (!enumType.isEnum) {
+            throw IllegalArgumentException("The given type is not an enum.")
+        }
+
+        possibleEnumValues = enumType.enumConstants.map(Any::toString)
+    }
+
+    /**
+     * Create a field description with the possible enum values.
+     * @param path json path of the field
+     */
+    fun withPath(path: String) =
+            addPossibleEnumValue(fieldWithPath(path))
+
+    private fun addPossibleEnumValue(fieldDescriptor: FieldDescriptor): FieldDescriptor =
+            fieldDescriptor.type(ENUM_TYPE).attributes(key(ENUM_VALUES_KEY).value(possibleEnumValues))
+
+    companion object {
+        private const val ENUM_TYPE = "enum"
+        private const val ENUM_VALUES_KEY = "enumValues"
+    }
+}

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/EnumFieldsTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/EnumFieldsTest.kt
@@ -1,0 +1,29 @@
+package com.epages.restdocs.apispec
+
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class EnumFieldsTest {
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should resolve possible enum values`() {
+        val descriptor = EnumFields(SomeEnum::class.java).withPath("someEnum")
+
+        then(descriptor.attributes).containsKey("enumValues")
+        then((descriptor.attributes["enumValues"] as List<String>))
+            .isEqualTo(SomeEnum.values().map(SomeEnum::toString))
+    }
+
+    @Test
+    fun `should throw IllegalArgumentException if parameter is no enum`() {
+        assertThrows<IllegalArgumentException> { EnumFields(Any().javaClass) }
+    }
+
+    private enum class SomeEnum {
+        FIRST_VALUE,
+        SECOND_VALUE,
+        THIRD_VALUE
+    }
+}


### PR DESCRIPTION
This PR adds support for documenting enum values in the generated schema.
See https://github.com/ePages-de/restdocs-api-spec/issues/87#issuecomment-477757571