### PR TITLE
Fix multiple parameters in path parsing

### DIFF
--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -34,11 +34,13 @@ import io.swagger.models.properties.PropertyBuilder
 import io.swagger.util.Json
 import java.util.Comparator.comparing
 import java.util.Comparator.comparingInt
+import java.util.regex.Pattern
 
 object OpenApi20Generator {
 
     private const val API_KEY_SECURITY_NAME = "api_key"
     private const val BASIC_SECURITY_NAME = "basic"
+    private val PATH_PARAMETER_PATTERN = """\{([^/}]+)}""".toRegex()
     internal fun generate(
         resources: List<ResourceModel>,
         basePath: String? = null,
@@ -322,10 +324,9 @@ object OpenApi20Generator {
     }
 
     private fun extractPathParameters(resourceModel: ResourceModel): List<PathParameter> {
-        val pathParameterNames = resourceModel.request.path
-            .split("/")
-            .filter { it.startsWith("{") && it.endsWith("}") }
-            .map { it.removePrefix("{").removeSuffix("}") }
+        val pathParameterNames = PATH_PARAMETER_PATTERN.findAll(resourceModel.request.path)
+                .map { matchResult -> matchResult.groupValues[1]  }
+                .toList()
 
         return pathParameterNames.map { parameterName ->
             resourceModel.request.pathParameters

--- a/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
+++ b/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
@@ -105,6 +105,15 @@ class OpenApi20GeneratorTest {
     }
 
     @Test
+    fun `should extract multiple path parameters from path as fallback`() {
+        val api = givenGetProductResourceModelWithoutMultiplePathParameters()
+
+        val openapi = whenOpenApiObjectGenerated(api)
+
+        thenMultiplePathParametersExist(openapi, api)
+    }
+
+    @Test
     fun `should convert resource with head http method`() {
         val api = givenHeadResourceModel()
 
@@ -256,6 +265,13 @@ class OpenApi20GeneratorTest {
         then(path.parameters.firstOrNull()).isNotNull
         val pathParameter = path.parameters.first { it is PathParameter } as PathParameter
         then(pathParameter.name).isEqualTo("id")
+    }
+
+    private fun thenMultiplePathParametersExist(openapi: Swagger, api: List<ResourceModel>) {
+        val path = openapi.paths.getValue(api[0].request.path).get
+        then(path.parameters).hasSize(2)
+        then(path.parameters[0].name).isEqualTo("id")
+        then(path.parameters[1].name).isEqualTo("subId")
     }
 
     private fun thenApiSpecificationWithoutJsonSchemaButWithExamplesIsGenerated(
@@ -426,6 +442,18 @@ class OpenApi20GeneratorTest {
                 request = getProductRequestWithoutPathParameters(),
                 response = getProduct200Response(getProductPayloadExample())
             )
+        )
+    }
+
+    private fun givenGetProductResourceModelWithoutMultiplePathParameters(): List<ResourceModel> {
+        return listOf(
+                ResourceModel(
+                        operationId = "test",
+                        privateResource = false,
+                        deprecated = false,
+                        request = getProductRequestWithoutMultiplePathParameters(),
+                        response = getProduct200Response(getProductPayloadExample())
+                )
         )
     }
 
@@ -760,6 +788,22 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             requestParameters = listOf(),
             requestFields = listOf()
+        )
+    }
+
+    private fun getProductRequestWithoutMultiplePathParameters(): RequestModel {
+        return RequestModel(
+                path = "/products/{id}-{subId}",
+                method = HTTPMethod.GET,
+                contentType = "application/json",
+                securityRequirements = SecurityRequirements(
+                        type = OAUTH2,
+                        requiredScopes = listOf("prod:r")
+                ),
+                headers = listOf(),
+                pathParameters = listOf(),
+                requestParameters = listOf(),
+                requestFields = listOf()
         )
     }
 

--- a/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
+++ b/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
@@ -108,7 +108,7 @@ class OpenApi20GeneratorTest {
 
     @Test
     fun `should extract multiple path parameters from path as fallback`() {
-        val api = givenGetProductResourceModelWithoutMultiplePathParameters()
+        val api = givenGetProductResourceModelWithMultiplePathParameters()
 
         val openapi = whenOpenApiObjectGenerated(api)
 
@@ -464,13 +464,13 @@ class OpenApi20GeneratorTest {
         )
     }
 
-    private fun givenGetProductResourceModelWithoutMultiplePathParameters(): List<ResourceModel> {
+    private fun givenGetProductResourceModelWithMultiplePathParameters(): List<ResourceModel> {
         return listOf(
                 ResourceModel(
                         operationId = "test",
                         privateResource = false,
                         deprecated = false,
-                        request = getProductRequestWithoutMultiplePathParameters(),
+                        request = getProductRequestWithMultiplePathParameters(),
                         response = getProduct200Response(getProductPayloadExample())
                 )
         )
@@ -816,7 +816,7 @@ class OpenApi20GeneratorTest {
         )
     }
 
-    private fun getProductRequestWithoutMultiplePathParameters(): RequestModel {
+    private fun getProductRequestWithMultiplePathParameters(): RequestModel {
         return RequestModel(
                 path = "/products/{id}-{subId}",
                 method = HTTPMethod.GET,

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -41,6 +41,7 @@ import io.swagger.v3.oas.models.tags.Tag
 
 object OpenApi3Generator {
 
+    private val PATH_PARAMETER_PATTERN = """\{([^/}]+)}""".toRegex()
     internal fun generate(
         resources: List<ResourceModel>,
         servers: List<Server>,
@@ -344,10 +345,9 @@ object OpenApi3Generator {
     }
 
     private fun extractPathParameters(resourceModel: ResourceModel): List<PathParameter> {
-        val pathParameterNames = resourceModel.request.path
-            .split("/")
-            .filter { it.startsWith("{") && it.endsWith("}") }
-            .map { it.removePrefix("{").removeSuffix("}") }
+        val pathParameterNames = PATH_PARAMETER_PATTERN.findAll(resourceModel.request.path)
+                .map { matchResult -> matchResult.groupValues[1]  }
+                .toList()
 
         return pathParameterNames.map { parameterName ->
             resourceModel.request.pathParameters

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -179,7 +179,7 @@ class OpenApi3GeneratorTest {
 
     @Test
     fun `should extract multiple parameters when seperated by delimiter`(){
-        givenResourceWithWithMultiplePathParameters()
+        givenResourceWithMultiplePathParameters()
 
         whenOpenApiObjectGenerated()
 
@@ -457,7 +457,7 @@ class OpenApi3GeneratorTest {
         )
     }
 
-    private fun givenResourceWithWithMultiplePathParameters() {
+    private fun givenResourceWithMultiplePathParameters() {
         resources = listOf(
                 ResourceModel(
                         operationId = "test",


### PR DESCRIPTION
Fixes issue where multiple parameters separated by a `-` were parsed incorrectly.
 issue: https://github.com/ePages-de/restdocs-api-spec/issues/115