### PR TITLE
[#113] Fix for application/x-www-form-urlencoded

### DIFF
--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -283,19 +283,18 @@ object OpenApi20Generator {
                         .filter { it.request.contentType != "application/x-www-form-urlencoded" }
                         .flatMap { it.request.requestParameters }
                         .distinctBy { it.name }
-                        .map { requestParameterDescriptor2QueryParameter(it)
-                }).plus(
+                        .map { requestParameterDescriptor2QueryParameter(it) }
+                ).plus(
                     modelsWithSamePathAndMethod
                         .filter { it.request.contentType == "application/x-www-form-urlencoded" }
                         .flatMap { it.request.requestParameters }
                         .distinctBy { it.name }
-                        .map { requestParameterDescriptor2FormParameter(it)
-                }).plus(
+                        .map { requestParameterDescriptor2FormParameter(it) }
+                ).plus(
                     modelsWithSamePathAndMethod
                         .flatMap { it.request.headers }
                         .distinctBy { it.name }
-                        .map { header2Parameter(it)
-                        }
+                        .map { header2Parameter(it) }
                 ).plus(
                     listOfNotNull<Parameter>(
                         requestFieldDescriptor2Parameter(

--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -26,6 +26,7 @@ import io.swagger.models.auth.ApiKeyAuthDefinition
 import io.swagger.models.auth.BasicAuthDefinition
 import io.swagger.models.auth.OAuth2Definition
 import io.swagger.models.parameters.BodyParameter
+import io.swagger.models.parameters.FormParameter
 import io.swagger.models.parameters.HeaderParameter
 import io.swagger.models.parameters.Parameter
 import io.swagger.models.parameters.PathParameter
@@ -279,10 +280,17 @@ object OpenApi20Generator {
                     firstModelForPathAndMethod
                 ).plus(
                     modelsWithSamePathAndMethod
+                        .filter { it.request.contentType != "application/x-www-form-urlencoded" }
                         .flatMap { it.request.requestParameters }
                         .distinctBy { it.name }
-                        .map { requestParameterDescriptor2Parameter(it)
-                        }).plus(
+                        .map { requestParameterDescriptor2QueryParameter(it)
+                }).plus(
+                    modelsWithSamePathAndMethod
+                        .filter { it.request.contentType == "application/x-www-form-urlencoded" }
+                        .flatMap { it.request.requestParameters }
+                        .distinctBy { it.name }
+                        .map { requestParameterDescriptor2FormParameter(it)
+                }).plus(
                     modelsWithSamePathAndMethod
                         .flatMap { it.request.headers }
                         .distinctBy { it.name }
@@ -412,8 +420,17 @@ object OpenApi20Generator {
         }
     }
 
-    private fun requestParameterDescriptor2Parameter(parameterDescriptor: ParameterDescriptor): QueryParameter {
+    private fun requestParameterDescriptor2QueryParameter(parameterDescriptor: ParameterDescriptor): QueryParameter {
         return QueryParameter().apply {
+            name = parameterDescriptor.name
+            description = parameterDescriptor.description
+            required = parameterDescriptor.optional.not()
+            type = parameterDescriptor.type.toLowerCase()
+        }
+    }
+
+    private fun requestParameterDescriptor2FormParameter(parameterDescriptor: ParameterDescriptor): FormParameter {
+        return FormParameter().apply {
             name = parameterDescriptor.name
             description = parameterDescriptor.description
             required = parameterDescriptor.optional.not()

--- a/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
+++ b/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
@@ -231,7 +231,7 @@ class OpenApi20GeneratorTest {
     }
 
     @Test
-    fun `should handle urlencoded body in POST request as a formData not query string`() {
+    fun `should handle urlencoded body in POST request as a formData`() {
         val api = givenResourceModelsWithApplicationForm(HTTPMethod.POST)
 
         val openapi = whenOpenApiObjectGenerated(api)
@@ -241,7 +241,7 @@ class OpenApi20GeneratorTest {
     }
 
     @Test
-    fun `should handle urlencoded body in PUT request as a formData not query string`() {
+    fun `should handle urlencoded body in PUT request as a formData`() {
         val api = givenResourceModelsWithApplicationForm(HTTPMethod.PUT)
 
         val openapi = whenOpenApiObjectGenerated(api)
@@ -884,18 +884,8 @@ class OpenApi20GeneratorTest {
                 method = method,
                 contentType = "application/x-www-form-urlencoded",
                 schema = schema,
-                securityRequirements = SecurityRequirements(
-                        type = OAUTH2,
-                        requiredScopes = listOf("prod:c")
-                ),
-                headers = listOf(
-                        HeaderDescriptor(
-                                name = "Authorization",
-                                description = "Access token",
-                                type = "STRING",
-                                optional = false
-                        )
-                ),
+                securityRequirements = null,
+                headers = listOf(),
                 pathParameters = listOf(),
                 requestParameters = listOf(
                         ParameterDescriptor(

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -224,6 +224,7 @@ object OpenApi3Generator {
                         firstModelForPathAndMethod
                     ).plus(
                         modelsWithSamePathAndMethod
+                                .filter { it.request.contentType != "application/x-www-form-urlencoded" }
                                 .flatMap { it.request.requestParameters }
                                 .distinctBy { it.name }
                                 .map { requestParameterDescriptor2Parameter(it)


### PR DESCRIPTION
Main point of this fix is to introduce proper payload documentation for OpenAPI 2.0 (changing type of parameter for a given Content-Type from query to formData) and OpenAPI 3.0 (moving payload definition from query parameters to requestBody).

It does not fix schema generation for OpenAPI 3.0 (it is still generating empty schema, although - it generates proper example if provided).

If merged, this closes #113