### PR TITLE
Use common snippet name prefix as operationId, fix #140

### DIFF
--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -219,6 +219,24 @@ class OpenApi3GeneratorTest {
         thenResourceHasValidSchemaGeneratedFromRequestParameters(method.toString().toLowerCase())
     }
 
+    @Test
+    fun `should determine operationId as common prefix of all snippet operationIds`() {
+        givenResourcesWithSamePathAndContentType()
+
+        whenOpenApiObjectGenerated()
+
+        then(openApiJsonPathContext.read<String>("paths./products/{id}.get.operationId")).isEqualTo("test")
+    }
+
+    @Test
+    fun `should determine operationId as concatenated operationIds if no common prefix exists`() {
+        givenResourcesWithSamePathAndContentTypeButOperationIdsWithoutCommonPrefix()
+
+        whenOpenApiObjectGenerated()
+
+        then(openApiJsonPathContext.read<String>("paths./products/{id}.get.operationId")).isEqualTo("firstsecond")
+    }
+
     fun thenResourceHasValidSchemaGeneratedFromRequestParameters(method: String) {
         val productGetByIdPath = "paths./products/{id}.$method"
         val getResponseSchemaRef = openApiJsonPathContext.read<String>("$productGetByIdPath.requestBody.content.application/x-www-form-urlencoded.schema.\$ref")
@@ -400,6 +418,31 @@ class OpenApi3GeneratorTest {
                 request = getProductRequest(),
                 response = getProductResponse()
             )
+        )
+    }
+
+    private fun givenResourcesWithSamePathAndContentTypeButOperationIdsWithoutCommonPrefix() {
+        resources = listOf(
+                ResourceModel(
+                        operationId = "first",
+                        summary = "summary",
+                        description = "description",
+                        privateResource = false,
+                        deprecated = false,
+                        tags = setOf("tag1", "tag2"),
+                        request = getProductRequest(),
+                        response = getProductResponse()
+                ),
+                ResourceModel(
+                        operationId = "second",
+                        summary = "summary 1",
+                        description = "description 1",
+                        privateResource = false,
+                        deprecated = false,
+                        tags = setOf("tag1", "tag2"),
+                        request = getProductRequest(),
+                        response = getProductResponse()
+                )
         )
     }
 


### PR DESCRIPTION
See https://github.com/ePages-de/restdocs-api-spec/issues/140 for problem description.

## Solution

### Example 1

Snippet IDs have a common prefix:

```
get-product
get-product_xml
get-product_with_extra_attributes
```

The resulting operationId would be the common prefix `get-product`

### Example 2

Snippet IDs do not have a common prefix:

```
first
second
last
```

The resulting operationId would be the snippet IDs sorted lexicographically and then concatenated resulting in `firstlastsecond`