### PR TITLE
Add support for content type parameters

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippet.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippet.kt
@@ -105,7 +105,7 @@ class ResourceSnippet(private val resourceSnippetParameters: ResourceSnippetPara
 
     private fun getContentTypeOrDefault(headers: HttpHeaders): String =
         Optional.ofNullable(headers.contentType)
-            .map { MediaType(it.type, it.subtype) }
+            .map { MediaType(it.type, it.subtype, it.parameters) }
             .orElse(APPLICATION_JSON)
             .toString()
 

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
@@ -175,14 +175,6 @@ class ResourceSnippetTest {
     @Test
     fun should_respect_content_type_parameters_for_response() {
         givenOperationWithRequestAndResponseBody(responseContentType = "application/json;format=format-1")
-        givenRequestFieldDescriptors()
-        givenRequestSchemaName()
-        givenResponseFieldDescriptors()
-        givenResponseSchemaName()
-        givenPathParameterDescriptors()
-        givenRequestParameterDescriptors()
-        givenRequestAndResponseHeaderDescriptors()
-        givenTag()
 
         whenResourceSnippetInvoked()
 

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
@@ -172,6 +172,24 @@ class ResourceSnippetTest {
         then(resourceSnippetJson.read<String>("operationId")).isEqualTo("resource-snippet-test/get-some-by-id")
     }
 
+    @Test
+    fun should_respect_content_type_parameters_for_response() {
+        givenOperationWithRequestAndResponseBody(responseContentType = "application/json;format=format-1")
+        givenRequestFieldDescriptors()
+        givenRequestSchemaName()
+        givenResponseFieldDescriptors()
+        givenResponseSchemaName()
+        givenPathParameterDescriptors()
+        givenRequestParameterDescriptors()
+        givenRequestAndResponseHeaderDescriptors()
+        givenTag()
+
+        whenResourceSnippetInvoked()
+
+        thenSnippetFileExists()
+        then(resourceSnippetJson.read<String>("response.contentType")).isEqualTo("application/json;format=format-1")
+    }
+
     private fun givenTag() {
         parametersBuilder.tag("some")
         parametersBuilder.tags("someOther", "somethingElse")
@@ -343,7 +361,7 @@ class ResourceSnippetTest {
             parameterWithName("obviousParameter").description("needs no documentation, too obvious").ignored())
     }
 
-    private fun givenOperationWithRequestAndResponseBody() {
+    private fun givenOperationWithRequestAndResponseBody(responseContentType: String = APPLICATION_JSON_VALUE) {
         val operationBuilder = OperationBuilder("test", rootOutputDirectory)
             .attribute(ATTRIBUTE_NAME_URL_TEMPLATE, "http://localhost:8080/some/{id}")
         val content = "{\"comment\": \"some\"}"
@@ -359,7 +377,7 @@ class ResourceSnippetTest {
             .response()
             .status(201)
             .header("X-SOME", "some")
-            .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+            .header(CONTENT_TYPE, responseContentType)
             .content(content)
         operation = operationBuilder.build()
     }


### PR DESCRIPTION
Fixes #142 

Followed conventions to my best knowledge - may be worth using kotlin built in nullable constructs instead of java optionals, but I did not want to change the coding style you chose.