### PR TITLE
Add redoc html generation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,9 +534,15 @@ postman {
 
 We can use [redoc](https://github.com/Rebilly/ReDoc) to generate an HTML API reference from our OpenAPI specification.
 
-The [redoc-cli](https://www.npmjs.com/package/redoc-cli) can be used to serve this API reference
+The [redoc-cli](https://www.npmjs.com/package/redoc-cli) can be used to just bundle or bundle & serve this API reference:
 ```
+# Install redoc-cli
 npm install -g redoc-cli
+
+# Just bundle into zero-dependency HTML-file
+redoc-cli bundle build/api-spec/openapi.json
+
+# Bundle and serve
 redoc-cli serve build/api-spec/openapi.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ The [redoc-cli](https://www.npmjs.com/package/redoc-cli) can be used to bundle (
 # Install redoc-cli
 npm install -g redoc-cli
 
-# Just bundle into zero-dependency HTML-file
+# Bundle the documentation into a zero-dependency HTML-file
 redoc-cli bundle build/api-spec/openapi.json
 
 # Bundle and serve

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ postman {
 
 We can use [redoc](https://github.com/Rebilly/ReDoc) to generate an HTML API reference from our OpenAPI specification.
 
-The [redoc-cli](https://www.npmjs.com/package/redoc-cli) can be used to just bundle or bundle & serve this API reference:
+The [redoc-cli](https://www.npmjs.com/package/redoc-cli) can be used to bundle (and serve) this API reference:
 ```
 # Install redoc-cli
 npm install -g redoc-cli

--- a/README.md
+++ b/README.md
@@ -222,8 +222,7 @@ mockMvc.perform(get("/carts/{id}", cartId)
         linkWithRel("order").description("Link to order the cart."))
     .build())));
 ```
-
-Please see the [CartIntegrationTest](samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/api-spec/sample/CartIntegrationTest.java) in the sample application for a detailed example.
+Please see the [CartIntegrationTest](samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/apispec/sample/CartIntegrationTest.java) in the sample application for a detailed example.
 
 **:warning: Use `template URIs` to refer to path variables in your request**
 


### PR DESCRIPTION
When I first read this readme, I thought that redoc could only serve it for me. After looking into the redoc-cli, I realized that it could just bundle me up a no-dependency HTML file. Knowing that redoc could also just produce an HTML file is something that a lot of people will likely be interested in.