### PR TITLE
fix: required constraint for objects

### DIFF
--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -97,7 +97,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
                             propertyName,
                             newTraversedSegments,
                             newFields,
-                            directMatch.fieldDescriptor.description as? String
+                            directMatch
                         )
                     }
                     true
@@ -131,7 +131,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
         propertyName: String,
         traversedSegments: MutableList<String>,
         fields: List<JsonFieldPath>,
-        description: String?
+        propertyField: JsonFieldPath? = null
     ) {
         val remainingSegments = fields[0].remainingSegments(traversedSegments)
         if (remainingSegments.isNotEmpty() && JsonFieldPath.isArraySegment(
@@ -142,14 +142,17 @@ class JsonSchemaFromFieldDescriptorsGenerator {
             builder.addPropertySchema(
                 propertyName, ArraySchema.builder()
                     .allItemSchema(traverse(traversedSegments, fields, ObjectSchema.builder()))
-                    .description(description)
+                    .description(propertyField?.fieldDescriptor?.description)
                     .build()
             )
         } else {
+            if (propertyField?.fieldDescriptor?.let { isRequired(it) } == true) {
+                builder.addRequiredProperty(propertyName)
+            }
             builder.addPropertySchema(
                 propertyName, traverse(
                     traversedSegments, fields, ObjectSchema.builder()
-                        .description(description) as ObjectSchema.Builder
+                        .description(propertyField?.fieldDescriptor?.description) as ObjectSchema.Builder
                 )
             )
         }

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -156,6 +156,18 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
     }
 
     @Test
+    fun should_generate_schema_for_required_object() {
+        givenFieldDescriptorWithRequiredObject()
+
+        whenSchemaGenerated()
+
+        then(schema).isInstanceOf(ObjectSchema::class.java)
+        thenSchemaIsValid()
+        val objSchema = schema!!.let { it as ObjectSchema }
+        then(objSchema.requiredProperties).contains("obj")
+    }
+
+    @Test
     fun should_fail_on_unknown_field_type() {
         givenFieldDescriptorWithInvalidType()
 
@@ -233,6 +245,14 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
 
     private fun givenFieldDescriptorWithPrimitiveArray() {
         fieldDescriptors = listOf(FieldDescriptor("a[]", "some", "ARRAY"))
+    }
+
+    private fun givenFieldDescriptorWithRequiredObject() {
+        val notNullConstraint = Attributes(listOf(Constraint(NotNull::class.java.name, emptyMap())))
+        fieldDescriptors = listOf(
+                FieldDescriptor("obj", "some", "OBJECT", attributes = notNullConstraint),
+                FieldDescriptor("obj.field", "some", "STRING")
+        )
     }
 
     private fun givenFieldDescriptorWithTopLevelArray() {


### PR DESCRIPTION
Required constraint was not propagated to OpenApi schema for fields of type 'OBJECT'.  
Fixes #138