### PR TITLE
GH-154 Allow override of the descriptor validation link extractor

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
@@ -4,8 +4,8 @@ import org.springframework.restdocs.headers.HeaderDescriptor
 import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
 import org.springframework.restdocs.headers.RequestHeadersSnippet
 import org.springframework.restdocs.headers.ResponseHeadersSnippet
-import org.springframework.restdocs.hypermedia.HypermediaDocumentation
 import org.springframework.restdocs.hypermedia.LinkDescriptor
+import org.springframework.restdocs.hypermedia.LinkExtractor
 import org.springframework.restdocs.hypermedia.LinksSnippet
 import org.springframework.restdocs.operation.Operation
 import org.springframework.restdocs.payload.FieldDescriptor
@@ -29,7 +29,7 @@ internal object DescriptorValidator {
             validateIfDescriptorsPresent(
                 links,
                 operation
-            ) { LinksSnippetWrapper(links) }
+            ) { LinksSnippetWrapper(links, linkExtractor) }
 
             validateIfDescriptorsPresent(
                 responseFieldsWithLinks,
@@ -174,7 +174,7 @@ internal object DescriptorValidator {
         }
     }
 
-    private class LinksSnippetWrapper(descriptors: List<LinkDescriptor>) : LinksSnippet(HypermediaDocumentation.halLinks(), descriptors),
+    private class LinksSnippetWrapper(descriptors: List<LinkDescriptor>, linkExtractor: LinkExtractor) : LinksSnippet(linkExtractor, descriptors),
         ValidateableSnippet {
         override fun validate(operation: Operation) {
             this.createModel(operation)

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
@@ -2,7 +2,9 @@ package com.epages.restdocs.apispec
 
 import com.epages.restdocs.apispec.SimpleType.STRING
 import org.springframework.restdocs.headers.HeaderDescriptor
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation
 import org.springframework.restdocs.hypermedia.LinkDescriptor
+import org.springframework.restdocs.hypermedia.LinkExtractor
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
@@ -28,7 +30,8 @@ data class ResourceSnippetParameters @JvmOverloads constructor(
     val requestParameters: List<ParameterDescriptorWithType> = emptyList(),
     val requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
     val responseHeaders: List<HeaderDescriptorWithType> = emptyList(),
-    val tags: Set<String> = emptySet()
+    val tags: Set<String> = emptySet(),
+    val linkExtractor: LinkExtractor = HypermediaDocumentation.halLinks()
 ) {
     val responseFieldsWithLinks by lazy { responseFields + links.map(Companion::toFieldDescriptor) }
 
@@ -190,6 +193,8 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
         private set
     var responseHeaders: List<HeaderDescriptorWithType> = emptyList()
         private set
+    var linkExtractor: LinkExtractor = HypermediaDocumentation.halLinks()
+        private set
 
     override fun summary(summary: String?) = apply { this.summary = summary }
     override fun description(description: String?) = apply { this.description = description }
@@ -236,6 +241,8 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
     override fun tag(tag: String) = tags(tag)
     override fun tags(vararg tags: String) = apply { this.tags += tags }
 
+    fun linkExtractor(linkExtractor: LinkExtractor) = apply { this.linkExtractor = linkExtractor }
+
     fun build() = ResourceSnippetParameters(
         summary,
         description,
@@ -250,6 +257,7 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
         requestParameters,
         requestHeaders,
         responseHeaders,
-        tags
+        tags,
+        linkExtractor
     )
 }


### PR DESCRIPTION
Address the request in #154 by allowing override of the link extractor used with descriptor validation, defaulting to the current behavior of using `HypermediaDocumentation.halLinks()`. Override is done via a field st]et in `ResourceSnippetParameters`, with associated builder methods, and consumed in `DescriptorValidator` in place of the previously hard-coded `halLinks()` value.

I am unsure what tests would be appropriate to add alongside this addition - however, all existing tests pass.

Please note, this is my first attempt at Kotlin in general, and I do not have Kotlin tooling set up - I did these edits by running Gradle wrapper from the command line and with an Atom text editor. I 100% expect I did some stuff wrong and adjustments will be needed, and I am hoping it conforms to whatever formatting standards are expected (I didn't see any contributor documentation, so just tried to mimic the existing code as best I could - if such documents exist and I just missed them, please feel free to point me at them so I can try to address anything in there this PR doesn't conform to).