### PR TITLE
GH-153: Stop publish Gradle plugin to Sonatype

### DIFF
--- a/ci_publish_java.sh
+++ b/ci_publish_java.sh
@@ -7,9 +7,10 @@ openssl aes-256-cbc -K $encrypted_7b7bcfd5be68_key -iv $encrypted_7b7bcfd5be68_i
   -d
 
 ./gradlew publishToSonatype \
-	--info \
-	-Dorg.gradle.project.sonatypeUsername="${SONATYPE_USERNAME}" \
-	-Dorg.gradle.project.sonatypePassword="${SONATYPE_PASSWORD}" \
- 	-Dorg.gradle.project.signing.keyId="${SIGNING_KEY_ID}" \
-	-Dorg.gradle.project.signing.password="${SIGNING_PASSWORD}" \
-	-Dorg.gradle.project.signing.secretKeyRingFile="${SIGNING_KEYRING_FILE}"
+  --info \
+  --exclude-task :restdocs-api-spec-gradle-plugin:publishToSonatype \
+  -Dorg.gradle.project.sonatypeUsername="${SONATYPE_USERNAME}" \
+  -Dorg.gradle.project.sonatypePassword="${SONATYPE_PASSWORD}" \
+  -Dorg.gradle.project.signing.keyId="${SIGNING_KEY_ID}" \
+  -Dorg.gradle.project.signing.password="${SIGNING_PASSWORD}" \
+  -Dorg.gradle.project.signing.secretKeyRingFile="${SIGNING_KEYRING_FILE}"


### PR DESCRIPTION
The validation after the attempt to close the staging repository at Sonatype failed because there are no Javadocs and signatures for the Gradle plugin.

![Nexus_Repository_Manager](https://user-images.githubusercontent.com/5235584/111455172-be32df00-8715-11eb-9a40-9e2e03d0db73.png)

The suggested solution is to circumvent this problem by just not publishing the Gradle Plugin there. Then there will also be no failing validations.

We don't need it there because it is already published to the Gradle Plugin Portal which is the standard repo for Gradle Plugins.
