### PR TITLE
Add test to reproduce issue #154

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/DescriptorValidator.kt
@@ -6,6 +6,7 @@ import org.springframework.restdocs.headers.RequestHeadersSnippet
 import org.springframework.restdocs.headers.ResponseHeadersSnippet
 import org.springframework.restdocs.hypermedia.HypermediaDocumentation
 import org.springframework.restdocs.hypermedia.LinkDescriptor
+import org.springframework.restdocs.hypermedia.LinkExtractor
 import org.springframework.restdocs.hypermedia.LinksSnippet
 import org.springframework.restdocs.operation.Operation
 import org.springframework.restdocs.payload.FieldDescriptor
@@ -29,7 +30,7 @@ internal object DescriptorValidator {
             validateIfDescriptorsPresent(
                 links,
                 operation
-            ) { LinksSnippetWrapper(links) }
+            ) { LinksSnippetWrapper(links, linkExtractor) }
 
             validateIfDescriptorsPresent(
                 responseFieldsWithLinks,
@@ -183,8 +184,8 @@ internal object DescriptorValidator {
         }
     }
 
-    private class LinksSnippetWrapper(descriptors: List<LinkDescriptor>) :
-        LinksSnippet(HypermediaDocumentation.halLinks(), descriptors),
+    private class LinksSnippetWrapper(descriptors: List<LinkDescriptor>, linkExtractor: LinkExtractor) :
+        LinksSnippet(linkExtractor, descriptors),
         ValidateableSnippet {
         override fun validate(operation: Operation) {
             this.createModel(operation)

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
@@ -2,7 +2,9 @@ package com.epages.restdocs.apispec
 
 import com.epages.restdocs.apispec.SimpleType.STRING
 import org.springframework.restdocs.headers.HeaderDescriptor
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation
 import org.springframework.restdocs.hypermedia.LinkDescriptor
+import org.springframework.restdocs.hypermedia.LinkExtractor
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
@@ -28,7 +30,8 @@ data class ResourceSnippetParameters @JvmOverloads constructor(
     val requestParameters: List<ParameterDescriptorWithType> = emptyList(),
     val requestHeaders: List<HeaderDescriptorWithType> = emptyList(),
     val responseHeaders: List<HeaderDescriptorWithType> = emptyList(),
-    val tags: Set<String> = emptySet()
+    val tags: Set<String> = emptySet(),
+    val linkExtractor: LinkExtractor = HypermediaDocumentation.halLinks()
 ) {
     val responseFieldsWithLinks by lazy { responseFields + links.map(Companion::toFieldDescriptor) }
 
@@ -193,6 +196,8 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
         private set
     var responseHeaders: List<HeaderDescriptorWithType> = emptyList()
         private set
+    var linkExtractor: LinkExtractor = HypermediaDocumentation.halLinks()
+        private set
 
     override fun summary(summary: String?) = apply { this.summary = summary }
     override fun description(description: String?) = apply { this.description = description }
@@ -246,6 +251,8 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
     override fun tag(tag: String) = tags(tag)
     override fun tags(vararg tags: String) = apply { this.tags += tags }
 
+    fun linkExtractor(linkExtractor: LinkExtractor) = apply { this.linkExtractor = linkExtractor }
+
     fun build() = ResourceSnippetParameters(
         summary,
         description,
@@ -260,6 +267,7 @@ class ResourceSnippetParametersBuilder : ResourceSnippetDetails() {
         requestParameters,
         requestHeaders,
         responseHeaders,
-        tags
+        tags,
+        linkExtractor
     )
 }

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippetParameters.kt
@@ -33,7 +33,13 @@ data class ResourceSnippetParameters @JvmOverloads constructor(
     val tags: Set<String> = emptySet(),
     val linkExtractor: LinkExtractor = HypermediaDocumentation.halLinks()
 ) {
-    val responseFieldsWithLinks by lazy { responseFields + links.map(Companion::toFieldDescriptor) }
+    val responseFieldsWithLinks by lazy {
+        if (linkExtractor::class == HypermediaDocumentation.halLinks()::class) {
+            responseFields + links.map(Companion::toFieldDescriptor)
+        } else {
+            responseFields
+        }
+    }
 
     companion object {
         @JvmStatic
@@ -68,7 +74,7 @@ data class ResourceSnippetParameters @JvmOverloads constructor(
          * @return
          */
         private fun createLinkFieldDescriptor(rel: String): FieldDescriptor {
-            val path = "_links.$rel"
+            val path = "_links.$rel" // HAL specific
             return Optional.ofNullable(
                 ReflectionUtils.findMethod(
                     PayloadDocumentation::class.java,

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
@@ -193,6 +193,7 @@ class ResourceSnippetTest {
         whenResourceSnippetInvoked()
 
         thenSnippetFileExists()
+        then(resourceSnippetJson.read<List<*>>("response.responseFields")).hasSize(1)
     }
 
     private fun givenTag() {
@@ -418,9 +419,6 @@ class ResourceSnippetTest {
 
     private fun givenLinkDescriptorAndAtomLinkExtractor() {
         parametersBuilder
-            .responseFields(
-                subsectionWithPath("links").ignored()
-            )
             .links(
                 linkWithRel("self").description("Link to this resource")
             )

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/ResourceSnippetTest.kt
@@ -17,11 +17,12 @@ import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.restdocs.generate.RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE
 import org.springframework.restdocs.headers.HeaderDocumentation
+import org.springframework.restdocs.hypermedia.HypermediaDocumentation
 import org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel
-import org.springframework.restdocs.hypermedia.LinkDescriptor
 import org.springframework.restdocs.operation.Operation
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath
 import java.io.File
 import java.io.IOException
 import java.nio.file.Path
@@ -187,7 +188,7 @@ class ResourceSnippetTest {
     @Test
     fun should_generate_resourcemodel_for_links_not_in_HAL_format() {
         givenOperationWithAtomLinksInResponse()
-        givenLinkDescriptor()
+        givenLinkDescriptorAndAtomLinkExtractor()
 
         whenResourceSnippetInvoked()
 
@@ -415,10 +416,15 @@ class ResourceSnippetTest {
         operation = operationBuilder.build()
     }
 
-    private fun givenLinkDescriptor() {
-        parametersBuilder.links(
-            linkWithRel("self").description("Link to this resource")
-        )
+    private fun givenLinkDescriptorAndAtomLinkExtractor() {
+        parametersBuilder
+            .responseFields(
+                subsectionWithPath("links").ignored()
+            )
+            .links(
+                linkWithRel("self").description("Link to this resource")
+            )
+            .linkExtractor(HypermediaDocumentation.atomLinks())
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
Issue: #154 
Suggested fix by @romeara (without test): #156 

I added a test for reproduction first and will apply changes from #156 

Test failure:
```
Links with the following relations were not found in the response: [self]
org.springframework.restdocs.snippet.SnippetException: Links with the following relations were not found in the response: [self]
	at org.springframework.restdocs.hypermedia.LinksSnippet.validate(LinksSnippet.java:166)
	at org.springframework.restdocs.hypermedia.LinksSnippet.createModel(LinksSnippet.java:123)
	at com.epages.restdocs.apispec.DescriptorValidator$LinksSnippetWrapper.validate(DescriptorValidator.kt:190)
	at com.epages.restdocs.apispec.DescriptorValidator.validateIfDescriptorsPresent(DescriptorValidator.kt:101)
	at com.epages.restdocs.apispec.DescriptorValidator.validatePresentParameters(DescriptorValidator.kt:29)
	at com.epages.restdocs.apispec.ResourceSnippet.document(ResourceSnippet.kt:30)
...
```