### PR TITLE
Remove redundant test

### DIFF
--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -82,6 +82,15 @@ class OpenApi3GeneratorTest {
         then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")).isNotNull()
         then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.examples.test-1")).isNotNull()
 
+        val schema1 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")
+        val schema2 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")
+        then(schema1).startsWith("#/components/schemas/products-id")
+        then(schema2).startsWith("#/components/schemas/products-id-")
+        then(schema1).isNotEqualTo(schema2)
+
+        then(openApiJsonPathContext.read<Any>("${schema1.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("${schema2.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
+
         thenOpenApiSpecIsValid()
     }
 
@@ -97,17 +106,18 @@ class OpenApi3GeneratorTest {
         then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json-patch+json.schema.\$ref")).isNotNull()
         then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json-patch+json.examples.test-1")).isNotNull()
 
-        val schema1 = openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")
-        val schema2 = openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")
+        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.examples.test")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.examples.test-1")).isNotNull()
+
+        val schema1 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")
+        val schema2 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")
         then(schema1).isEqualTo("#/components/schemas/schema1")
         then(schema2).isEqualTo("#/components/schemas/schema2")
 
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.examples.test")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.examples.test-1")).isNotNull()
-
-        val componentsSchemaPath = "components.schemas"
-        then(openApiJsonPathContext.read<Any>("$componentsSchemaPath.schema1")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$componentsSchemaPath.schema2")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("${schema1.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
+        then(openApiJsonPathContext.read<Any>("${schema2.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
 
         thenOpenApiSpecIsValid()
     }

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -66,7 +66,7 @@ class OpenApi3GeneratorTest {
     }
 
     @Test
-    fun `should aggregate responses with different content type`() {
+    fun `should aggregate responses with different content type and different response schema`() {
         givenResourcesWithSamePathAndDifferentContentType()
 
         whenOpenApiObjectGenerated()

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -67,35 +67,6 @@ class OpenApi3GeneratorTest {
 
     @Test
     fun `should aggregate responses with different content type and different response schema`() {
-        givenResourcesWithSamePathAndDifferentContentType()
-
-        whenOpenApiObjectGenerated()
-
-        val productPatchByIdPath = "paths./products/{id}.patch"
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json.schema.\$ref")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json.examples.test")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json-patch+json.schema.\$ref")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.requestBody.content.application/json-patch+json.examples.test-1")).isNotNull()
-
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/json.examples.test")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("$productPatchByIdPath.responses.200.content.application/hal+json.examples.test-1")).isNotNull()
-
-        val schema1 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/json.schema.\$ref")
-        val schema2 = openApiJsonPathContext.read<String>("$productPatchByIdPath.responses.200.content.application/hal+json.schema.\$ref")
-        then(schema1).startsWith("#/components/schemas/products-id")
-        then(schema2).startsWith("#/components/schemas/products-id-")
-        then(schema1).isNotEqualTo(schema2)
-
-        then(openApiJsonPathContext.read<Any>("${schema1.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
-        then(openApiJsonPathContext.read<Any>("${schema2.replaceFirst("#/", "").replace("/", ".")}")).isNotNull()
-
-        thenOpenApiSpecIsValid()
-    }
-
-    @Test
-    fun `should segregate responses schema with different content type and different response schema`() {
         givenResourcesWithSamePathAndDifferentContentTypeAndDifferentResponseSchema()
 
         whenOpenApiObjectGenerated()
@@ -583,31 +554,6 @@ class OpenApi3GeneratorTest {
                 tags = setOf("tag1", "tag2"),
                 request = getProductRequest(),
                 response = getProductResponse()
-            )
-        )
-    }
-
-    private fun givenResourcesWithSamePathAndDifferentContentType() {
-        resources = listOf(
-            ResourceModel(
-                operationId = "test",
-                summary = "summary",
-                description = "description",
-                privateResource = false,
-                deprecated = false,
-                tags = setOf("tag1", "tag2"),
-                request = getProductPatchRequest(),
-                response = getProductResponse()
-            ),
-            ResourceModel(
-                operationId = "test-1",
-                summary = "summary 1",
-                description = "description 1",
-                privateResource = false,
-                deprecated = false,
-                tags = setOf("tag1", "tag2"),
-                request = getProductPatchJsonPatchRequest(),
-                response = getProductHalResponse()
             )
         )
     }


### PR DESCRIPTION
Cleanup after https://github.com/ePages-de/restdocs-api-spec/pull/174

1. Both tests basically had the same given/setup, except the 2nd test had explicit schema names whereas the first test had no schema names specified (resulting in schema names getting generated later)
1. In the first commit, I aligned the assertions of the existing test with the assertions of the new test, essentially making them equal
1. Thus the old test could be removed