### PR TITLE
Reproducer 181

### DIFF
--- a/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
+++ b/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
@@ -73,6 +73,15 @@ class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTes
     }
 
     @Test
+    fun should_document_restdocs_and_resource_snippet_details_with_parameter_with_type() {
+        givenEndpointInvoked()
+
+        whenDocumentedWithResourceSnippetDetailsWithParameterWithType()
+
+        thenSnippetFileExists()
+    }
+
+    @Test
     fun should_document_request() {
         givenEndpointInvoked()
 
@@ -260,6 +269,48 @@ class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTes
                         .tag("some-tag"),
                     requestPreprocessor = operationRequestPreprocessor,
                     snippets = arrayOf(
+                        requestFields(fieldDescriptors().fieldDescriptors),
+                        responseFields(
+                            fieldWithPath("comment").description("the comment"),
+                            fieldWithPath("flag").description("the flag"),
+                            fieldWithPath("count").description("the count"),
+                            fieldWithPath("id").description("id"),
+                            subsectionWithPath("_links").ignored()
+                        ),
+                        links(
+                            linkWithRel("self").description("some"),
+                            linkWithRel("multiple").description("multiple")
+                        )
+                    )
+                )
+            )
+    }
+
+    @Throws(Exception::class)
+    private fun whenDocumentedWithResourceSnippetDetailsWithParameterWithType() {
+        val operationRequestPreprocessor = OperationRequestPreprocessor { r -> r }
+        bodyContentSpec
+            .consumeWith(
+                WebTestClientRestDocumentationWrapper.document(
+                    identifier = operationName,
+                    resourceDetails = ResourceSnippetParametersBuilder()
+                        .description("The Resource")
+                        .privateResource(true)
+                        .tag("some-tag")
+                        .pathParameters(
+                            ParameterDescriptorWithType("someId")
+                                .type(SimpleType.BOOLEAN)
+                                .description("someId"),
+                            ParameterDescriptorWithType("otherId")
+                                .type(SimpleType.NUMBER)
+                                .description("otherId")
+                        ),
+                    requestPreprocessor = operationRequestPreprocessor,
+                    snippets = arrayOf(
+                        pathParameters(
+                            parameterWithName("someId").description("someId"),
+                            parameterWithName("otherId").description("otherId")
+                        ),
                         requestFields(fieldDescriptors().fieldDescriptors),
                         responseFields(
                             fieldWithPath("comment").description("the comment"),

--- a/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
+++ b/restdocs-api-spec-webtestclient/src/test/kotlin/com/epages/restdocs/apispec/WebTestClientRestDocumentationWrapperIntegrationTest.kt
@@ -293,35 +293,32 @@ class WebTestClientRestDocumentationWrapperIntegrationTest(@Autowired val webTes
             .consumeWith(
                 WebTestClientRestDocumentationWrapper.document(
                     identifier = operationName,
-                    resourceDetails = ResourceSnippetParametersBuilder()
-                        .description("The Resource")
-                        .privateResource(true)
-                        .tag("some-tag")
-                        .pathParameters(
-                            ParameterDescriptorWithType("someId")
-                                .type(SimpleType.BOOLEAN)
-                                .description("someId"),
-                            ParameterDescriptorWithType("otherId")
-                                .type(SimpleType.NUMBER)
-                                .description("otherId")
-                        ),
                     requestPreprocessor = operationRequestPreprocessor,
                     snippets = arrayOf(
-                        pathParameters(
-                            parameterWithName("someId").description("someId"),
-                            parameterWithName("otherId").description("otherId")
-                        ),
-                        requestFields(fieldDescriptors().fieldDescriptors),
-                        responseFields(
-                            fieldWithPath("comment").description("the comment"),
-                            fieldWithPath("flag").description("the flag"),
-                            fieldWithPath("count").description("the count"),
-                            fieldWithPath("id").description("id"),
-                            subsectionWithPath("_links").ignored()
-                        ),
-                        links(
-                            linkWithRel("self").description("some"),
-                            linkWithRel("multiple").description("multiple")
+                        resource(
+                            ResourceSnippetParametersBuilder()
+                                .description("The Resource")
+                                .privateResource(true)
+                                .tag("some-tag")
+                                .pathParameters(
+                                    ParameterDescriptorWithType("someId")
+                                        .type(SimpleType.BOOLEAN)
+                                        .description("someId"),
+                                    ParameterDescriptorWithType("otherId")
+                                        .type(SimpleType.NUMBER)
+                                        .description("otherId")
+                                )
+                                .requestFields(fieldDescriptors().fieldDescriptors)
+                                .responseFields(
+                                    fieldWithPath("comment").description("the comment"),
+                                    fieldWithPath("flag").description("the flag"),
+                                    fieldWithPath("count").description("the count"),
+                                    fieldWithPath("id").description("id"),
+                                    subsectionWithPath("_links").ignored()
+                                ).links(
+                                    linkWithRel("self").description("some"),
+                                    linkWithRel("multiple").description("multiple")
+                                ).build()
                         )
                     )
                 )


### PR DESCRIPTION
See #181 

PR just for convenience to see the difference. **DO NOT MERGE**

Produces:
```
{
  "operationId" : "test-1628624335625",
  "summary" : "The Resource",
  "description" : "The Resource",
  "privateResource" : true,
  "deprecated" : false,
  "request" : {
    "path" : "/some/{someId}/other/{otherId}",
    "method" : "POST",
    "contentType" : "application/json",
    "schema" : null,
    "headers" : [ ],
    "pathParameters" : [ {
      "name" : "someId",
      "attributes" : { },
      "description" : "someId",
      "ignored" : false,
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "name" : "otherId",
      "attributes" : { },
      "description" : "otherId",
      "ignored" : false,
      "type" : "NUMBER",
      "optional" : false
    } ],
    "requestParameters" : [ ],
    "requestFields" : [ {
      "attributes" : {
        "validationConstraints" : [ {
          "name" : "org.hibernate.validator.constraints.Length",
          "configuration" : {
            "groups" : [ ],
            "min" : 1,
            "message" : "{org.hibernate.validator.constraints.Length.message}",
            "max" : 255,
            "payload" : [ ]
          }
        } ]
      },
      "description" : "the comment",
      "ignored" : false,
      "path" : "comment",
      "type" : "STRING",
      "optional" : true
    }, {
      "attributes" : {
        "validationConstraints" : [ ]
      },
      "description" : "the flag",
      "ignored" : false,
      "path" : "flag",
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "attributes" : {
        "validationConstraints" : [ ]
      },
      "description" : "the count",
      "ignored" : false,
      "path" : "count",
      "type" : "NUMBER",
      "optional" : false
    } ],
    "example" : "{\n                            \"comment\": \"some\",\n                            \"flag\": true,\n                            \"count\": 1\n                        }",
    "securityRequirements" : null
  },
  "response" : {
    "status" : 200,
    "contentType" : "application/hal+json",
    "schema" : null,
    "headers" : [ ],
    "responseFields" : [ {
      "attributes" : { },
      "description" : "the comment",
      "ignored" : false,
      "path" : "comment",
      "type" : "STRING",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "the flag",
      "ignored" : false,
      "path" : "flag",
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "the count",
      "ignored" : false,
      "path" : "count",
      "type" : "NUMBER",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "id",
      "ignored" : false,
      "path" : "id",
      "type" : "STRING",
      "optional" : false
    } ],
    "example" : "{\"comment\":\"some\",\"flag\":true,\"count\":1,\"id\":\"aecafcd4-da09-4f23-8d77-8f4916a2b4c7\",\"_links\":{\"self\":{\"href\":\"http://localhost:8080/some/id/other/1\"},\"multiple\":[{\"href\":\"http://localhost:8080/some/id/other/1\"},{\"href\":\"http://localhost:8080/some/id/other/1\"}]}}"
  },
  "tags" : [ "some-tag" ]
}
```

Instead of the following from https://github.com/jgazeau/restdocs-api-spec/tree/reproducer-181 :
```
{
  "operationId" : "test-1628623066570",
  "summary" : "The Resource",
  "description" : "The Resource",
  "privateResource" : true,
  "deprecated" : false,
  "request" : {
    "path" : "/some/{someId}/other/{otherId}",
    "method" : "POST",
    "contentType" : "application/json",
    "schema" : null,
    "headers" : [ ],
    "pathParameters" : [ {
      "name" : "someId",
      "attributes" : { },
      "description" : "someId",
      "ignored" : false,
      "type" : "STRING",
      "optional" : false
    }, {
      "name" : "otherId",
      "attributes" : { },
      "description" : "otherId",
      "ignored" : false,
      "type" : "STRING",
      "optional" : false
    } ],
    "requestParameters" : [ ],
    "requestFields" : [ {
      "attributes" : {
        "validationConstraints" : [ {
          "name" : "org.hibernate.validator.constraints.Length",
          "configuration" : {
            "groups" : [ ],
            "min" : 1,
            "message" : "{org.hibernate.validator.constraints.Length.message}",
            "max" : 255,
            "payload" : [ ]
          }
        } ]
      },
      "description" : "the comment",
      "ignored" : false,
      "path" : "comment",
      "type" : "STRING",
      "optional" : true
    }, {
      "attributes" : {
        "validationConstraints" : [ ]
      },
      "description" : "the flag",
      "ignored" : false,
      "path" : "flag",
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "attributes" : {
        "validationConstraints" : [ ]
      },
      "description" : "the count",
      "ignored" : false,
      "path" : "count",
      "type" : "NUMBER",
      "optional" : false
    } ],
    "example" : "{\n                            \"comment\": \"some\",\n                            \"flag\": true,\n                            \"count\": 1\n                        }",
    "securityRequirements" : null
  },
  "response" : {
    "status" : 200,
    "contentType" : "application/hal+json",
    "schema" : null,
    "headers" : [ ],
    "responseFields" : [ {
      "attributes" : { },
      "description" : "the comment",
      "ignored" : false,
      "path" : "comment",
      "type" : "STRING",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "the flag",
      "ignored" : false,
      "path" : "flag",
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "the count",
      "ignored" : false,
      "path" : "count",
      "type" : "NUMBER",
      "optional" : false
    }, {
      "attributes" : { },
      "description" : "id",
      "ignored" : false,
      "path" : "id",
      "type" : "STRING",
      "optional" : false
    } ],
    "example" : "{\"comment\":\"some\",\"flag\":true,\"count\":1,\"id\":\"daa5721c-c0d9-400a-b36b-089caa97fe0e\",\"_links\":{\"self\":{\"href\":\"http://localhost:8080/some/id/other/1\"},\"multiple\":[{\"href\":\"http://localhost:8080/some/id/other/1\"},{\"href\":\"http://localhost:8080/some/id/other/1\"}]}}"
  },
  "tags" : [ "some-tag" ]
}
```

Notice the difference in pathParameters types, here:
```
    "pathParameters" : [ {
      "name" : "someId",
      "attributes" : { },
      "description" : "someId",
      "ignored" : false,
      "type" : "BOOLEAN",
      "optional" : false
    }, {
      "name" : "otherId",
      "attributes" : { },
      "description" : "otherId",
      "ignored" : false,
      "type" : "NUMBER",
      "optional" : false
    } ],
```

https://github.com/jgazeau/restdocs-api-spec/tree/reproducer-181 :
```
    "pathParameters" : [ {
      "name" : "someId",
      "attributes" : { },
      "description" : "someId",
      "ignored" : false,
      "type" : "STRING",
      "optional" : false
    }, {
      "name" : "otherId",
      "attributes" : { },
      "description" : "otherId",
      "ignored" : false,
      "type" : "STRING",
      "optional" : false
    } ],
```

