### PR TITLE
fix: better management of numbers in OpenApi3Generator

### DIFF
--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -456,21 +456,15 @@ object OpenApi3Generator {
                     .forEach { this.addEnumItem(it) }
             }
             SimpleType.NUMBER.name.toLowerCase() -> NumberSchema().apply {
-                this._default(parameterDescriptor.defaultValue?.let { it as BigDecimal })
+                this._default(parameterDescriptor.defaultValue?.asBigDecimal())
                 parameterDescriptor.attributes.enumValues
-                    .map {
-                        when (it) {
-                            is Int -> it.toBigDecimal()
-                            is Double -> it.toBigDecimal()
-                            else -> it as BigDecimal
-                        }
-                    }
+                    .map { it.asBigDecimal() }
                     .forEach { this.addEnumItem(it) }
             }
             SimpleType.INTEGER.name.toLowerCase() -> IntegerSchema().apply {
-                this._default(parameterDescriptor.defaultValue?.let { it as Int })
+                this._default(parameterDescriptor.defaultValue?.asInt())
                 parameterDescriptor.attributes.enumValues
-                    .map { it as Int }
+                    .map { it.asInt() }
                     .forEach { this.addEnumItem(it) }
             }
             else -> throw IllegalArgumentException("Unknown type '${parameterDescriptor.type}'")
@@ -483,6 +477,24 @@ object OpenApi3Generator {
 
     private fun <T> List<T>.nullIfEmpty(): List<T>? {
         return if (this.isEmpty()) null else this
+    }
+
+    private fun Any.asInt(): Int {
+        return when (this) {
+            is Int -> this
+            is Long -> toInt()
+            else -> this as Int
+        }
+    }
+
+    private fun Any.asBigDecimal(): BigDecimal {
+        return when (this) {
+            is Int -> toBigDecimal()
+            is Long -> toBigDecimal()
+            is Double -> toBigDecimal()
+            is Float -> toBigDecimal()
+            else -> this as BigDecimal
+        }
     }
 
     private data class RequestModelWithOperationId(

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -288,8 +288,39 @@ class OpenApi3GeneratorTest {
                 (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
         }
         then(params).anyMatch {
+            it["name"] == "intNumberParameter" &&
+                it["description"] == "a int number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
+        }
+        then(params).anyMatch {
+            it["name"] == "longNumberParameter" &&
+                it["description"] == "a long number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
+        }
+        then(params).anyMatch {
+            it["name"] == "doubleNumberParameter" &&
+                it["description"] == "a double number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1.0
+        }
+        then(params).anyMatch {
+            it["name"] == "floatNumberParameter" &&
+                it["description"] == "a float number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1.0
+        }
+        then(params).anyMatch {
             it["name"] == "integerParameter" &&
                 it["description"] == "a integer parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "integer" &&
+                (it["schema"] as LinkedHashMap<*, *>)["format"] == "int32" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 2
+        }
+        then(params).anyMatch {
+            it["name"] == "longIntegerParameter" &&
+                it["description"] == "a long integer parameter" &&
                 (it["schema"] as LinkedHashMap<*, *>)["type"] == "integer" &&
                 (it["schema"] as LinkedHashMap<*, *>)["format"] == "int32" &&
                 (it["schema"] as LinkedHashMap<*, *>)["default"] == 2
@@ -313,13 +344,44 @@ class OpenApi3GeneratorTest {
                 (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
         }
         then(params).anyMatch {
+            it["name"] == "X-SOME-INT-NUMBER" &&
+                it["description"] == "a header int number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
+        }
+        then(params).anyMatch {
+            it["name"] == "X-SOME-LONG-NUMBER" &&
+                it["description"] == "a header long number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1
+        }
+        then(params).anyMatch {
+            it["name"] == "X-SOME-DOUBLE-NUMBER" &&
+                it["description"] == "a header double number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1.0
+        }
+        then(params).anyMatch {
+            it["name"] == "X-SOME-FLOAT-NUMBER" &&
+                it["description"] == "a header float number parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "number" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 1.0
+        }
+        then(params).anyMatch {
             it["name"] == "X-SOME-INTEGER" &&
                 it["description"] == "a header integer parameter" &&
                 (it["schema"] as LinkedHashMap<*, *>)["type"] == "integer" &&
                 (it["schema"] as LinkedHashMap<*, *>)["format"] == "int32" &&
                 (it["schema"] as LinkedHashMap<*, *>)["default"] == 2
         }
-        then(params).hasSize(9)
+        then(params).anyMatch {
+            it["name"] == "X-SOME-LONG-INTEGER" &&
+                it["description"] == "a header long integer parameter" &&
+                (it["schema"] as LinkedHashMap<*, *>)["type"] == "integer" &&
+                (it["schema"] as LinkedHashMap<*, *>)["format"] == "int32" &&
+                (it["schema"] as LinkedHashMap<*, *>)["default"] == 2
+        }
+        then(params).hasSize(19)
 
         thenOpenApiSpecIsValid()
     }
@@ -1206,11 +1268,46 @@ class OpenApi3GeneratorTest {
                     defaultValue = 1.toBigDecimal()
                 ),
                 HeaderDescriptor(
+                    name = "X-SOME-INT-NUMBER",
+                    description = "a header int number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    defaultValue = 1
+                ),
+                HeaderDescriptor(
+                    name = "X-SOME-LONG-NUMBER",
+                    description = "a header long number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    defaultValue = 1L
+                ),
+                HeaderDescriptor(
+                    name = "X-SOME-DOUBLE-NUMBER",
+                    description = "a header double number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    defaultValue = 1.0
+                ),
+                HeaderDescriptor(
+                    name = "X-SOME-FLOAT-NUMBER",
+                    description = "a header float number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    defaultValue = 1.toFloat()
+                ),
+                HeaderDescriptor(
                     name = "X-SOME-INTEGER",
                     description = "a header integer parameter",
                     type = "INTEGER",
                     optional = true,
                     defaultValue = 2
+                ),
+                HeaderDescriptor(
+                    name = "X-SOME-LONG-INTEGER",
+                    description = "a header long integer parameter",
+                    type = "INTEGER",
+                    optional = true,
+                    defaultValue = 2L
                 )
             ),
             requestParameters = listOf(
@@ -1239,12 +1336,52 @@ class OpenApi3GeneratorTest {
                     defaultValue = 1.toBigDecimal()
                 ),
                 ParameterDescriptor(
+                    name = "intNumberParameter",
+                    description = "a int number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    ignored = false,
+                    defaultValue = 1
+                ),
+                ParameterDescriptor(
+                    name = "longNumberParameter",
+                    description = "a long number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    ignored = false,
+                    defaultValue = 1L
+                ),
+                ParameterDescriptor(
+                    name = "doubleNumberParameter",
+                    description = "a double number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    ignored = false,
+                    defaultValue = 1.0
+                ),
+                ParameterDescriptor(
+                    name = "floatNumberParameter",
+                    description = "a float number parameter",
+                    type = "NUMBER",
+                    optional = true,
+                    ignored = false,
+                    defaultValue = 1.toFloat()
+                ),
+                ParameterDescriptor(
                     name = "integerParameter",
                     description = "a integer parameter",
                     type = "INTEGER",
                     optional = true,
                     ignored = false,
                     defaultValue = 2
+                ),
+                ParameterDescriptor(
+                    name = "longIntegerParameter",
+                    description = "a long integer parameter",
+                    type = "INTEGER",
+                    optional = true,
+                    ignored = false,
+                    defaultValue = 2L
                 )
             )
         )


### PR DESCRIPTION
Hello,
I found an issue with defaultValue management when generating the OpenApi.

When generating the resource snippet from Spring restdocs they can look like that:
```
"requestParameters" : [ {
      "name" : "one",
      "attributes" : { },
      "description" : "BigDecimal query param",
      "ignored" : false,
      "type" : "NUMBER",
      "optional" : false,
      "default" : 1
    }
```

When using ePages to generate the associated API, the `NUMBER` with value `1` is interprated as an Integer and casting it as a BigDecimal will fail. (e.g. class java.math.Integer cannot be cast to class java.math.BigDecimal)

Because a BigDecimal has no string representation, and parsing the resource.json from spring restdocs to the ePages ResourceModel has an [`Any` type for the defaultValue](https://github.com/ePages-de/restdocs-api-spec/blob/master/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt#L66), numbers should be transformed to BigDecimal but not casted.

I've created this PR to solve it, as well as enhancing tests to check all possible cases.
(For the OpenAPIv2 no changes to be done as default value is not managed)

Kr,

Jordan.