### PR TITLE
Fix extracting standard scope claim in OAuth2 JWT

### DIFF
--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/JwtSecurityHandler.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/JwtSecurityHandler.kt
@@ -62,8 +62,12 @@ internal class JwtSecurityHandler : SecurityRequirementsExtractor {
             try {
                 val jwtMap = ObjectMapper().readValue<Map<String, Any>>(decodedPayload)
                 val scope = jwtMap["scope"]
+                // some of oauth2 authorization servers might return scope claims as a set of string
                 if (scope is List<*>) {
                     return scope as List<String>
+                }
+                if (scope is String) { // standard way of expressing scope claim
+                    return scope.trim().split("\\s+".toRegex())
                 }
             } catch (e: IOException) {
                 // probably not JWT

--- a/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/JwtSecurityHandlerTest.kt
+++ b/restdocs-api-spec/src/test/kotlin/com/epages/restdocs/apispec/JwtSecurityHandlerTest.kt
@@ -24,6 +24,16 @@ class JwtSecurityHandlerTest {
     }
 
     @Test
+    fun `should add scope list when standard oauth2 jwt is found in Authorization header`() {
+        givenRequestWithStandardOAuth2JwtInAuthorizationHeader()
+
+        whenSecurityRequirementsExtracted(operation)
+
+        then(securityRequirement).isNotNull
+        then((securityRequirement as Oauth2).requiredScopes).containsExactly("scope1", "scope2")
+    }
+
+    @Test
     fun `should return SecurityType of JWTBearer when non oauth2 jwt is found in Authorization header`() {
         givenRequestWithNonOAuth2JwtInAuthorizationHeader()
 
@@ -68,6 +78,15 @@ class JwtSecurityHandlerTest {
             .header(
                 AUTHORIZATION,
                 "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6WyJzY29wZTEiLCJzY29wZTIiXSwiZXhwIjoxNTA3NzU4NDk4LCJpYXQiOjE1MDc3MTUyOTgsImp0aSI6IjQyYTBhOTFhLWQ2ZWQtNDBjYy1iMTA2LWU5MGNkYWU0M2Q2ZCJ9.eWGo7Y124_Hdrr-bKX08d_oCfdgtlGXo9csz-hvRhRORJi_ZK7PIwM0ChqoLa4AhR-dJ86npid75GB9IxCW2f5E24FyZW2p5swpOpfkEAA4oFuj7jxHiaiqL_HFKKCRsVNAN3hGiSp9Hn3fde0-LlABqMaihdzZzHL-xm8-CqbXT-qBfuscDImZrZQZqhizpSEV4idbEMzZykggLASGoOIL0t0ycfe3yeuQkMUhzZmXuu08VM7zXwWnqfXCa-RmA6wC7ZnWqiJoi0vBr4BrlLR067YoUrT6pgRfiy2HZ0vEE_XY5SBtA-qI2QnlJb7eTk7pgFtoGkYdeOZ86k6GDVw"
+            )
+            .build()
+    }
+
+    private fun givenRequestWithStandardOAuth2JwtInAuthorizationHeader() {
+        operation = OperationBuilder().request("/some")
+            .header(
+                AUTHORIZATION,
+                "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlMSBzY29wZTIiLCJleHAiOjE1MDc3NTg0OTgsImlhdCI6MTUwNzcxNTI5OCwianRpIjoiNDJhMGE5MWEtZDZlZC00MGNjLWIxMDYtZTkwY2RhZTQzZDZkIn0.yLPUhfQ5IIWaTwLO1qcGzAjXtqXnx-FRiF_yGQkiO2M"
             )
             .build()
     }


### PR DESCRIPTION
fixes ePages-de/restdocs-api-spec#217
This fixes does not break current implementation of treating scope claim as List<String>