### PR TITLE
Make classes in restdocs-api-spec modules visible

### DIFF
--- a/restdocs-api-spec-mockmvc/build.gradle.kts
+++ b/restdocs-api-spec-mockmvc/build.gradle.kts
@@ -14,7 +14,7 @@ val junitVersion: String by extra
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
-    implementation(project(":restdocs-api-spec"))
+    api(project(":restdocs-api-spec"))
     implementation("org.springframework.restdocs:spring-restdocs-mockmvc:$springRestDocsVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {


### PR DESCRIPTION
Fixes ePages-de/restdocs-api-spec#222