### PR TITLE
feat: apply field optional

### DIFF
--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/ConstraintResolver.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/ConstraintResolver.kt
@@ -87,7 +87,6 @@ internal object ConstraintResolver {
             REQUIRED_CONSTRAINTS.contains(constraint.name)
         } || !fieldDescriptor.optional
 
-
     private fun findConstraints(fieldDescriptor: FieldDescriptor): List<Constraint> =
         fieldDescriptor.attributes.validationConstraints
 }

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/ConstraintResolver.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/ConstraintResolver.kt
@@ -82,9 +82,11 @@ internal object ConstraintResolver {
             .minOrNull()
     }
 
-    internal fun isRequired(fieldDescriptor: FieldDescriptor): Boolean =
-        findConstraints(fieldDescriptor)
-            .any { constraint -> REQUIRED_CONSTRAINTS.contains(constraint.name) }
+    internal fun isRequired(fieldDescriptor: FieldDescriptor): Boolean = findConstraints(fieldDescriptor)
+        .any { constraint ->
+            REQUIRED_CONSTRAINTS.contains(constraint.name)
+        } || !fieldDescriptor.optional
+
 
     private fun findConstraints(fieldDescriptor: FieldDescriptor): List<Constraint> =
         fieldDescriptor.attributes.validationConstraints

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -655,7 +655,7 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             ),
 
             FieldDescriptor("lineItems[*].quantity.unit", "some", "STRING"),
-            FieldDescriptor("shippingAddress", "some", "OBJECT"),
+            FieldDescriptor("shippingAddress", "some", "OBJECT", true),
             FieldDescriptor("billingAddress", "some", "OBJECT"),
             FieldDescriptor(
                 "billingAddress.firstName", "some", "STRING",
@@ -732,6 +732,7 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
                 "pagePositive",
                 "some",
                 "NUMBER",
+                true,
                 attributes = Attributes(
                     listOf(
                         Constraint(


### PR DESCRIPTION
# summary
- The optional attribute of the org.springframework.restdocs.payload.FieldDescriptor object allows expressing the required status.

# story
![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/de158f2a-05b7-4d37-9efe-57da9d5b5b0d)
First of all, thank you so much. Our team has been easily composing documentation for the OpenAPI3 spec using your code and RestDocs. However, there's one thing that's disappointing: we can't indicate the required status in this documentation. It seems like our team, as well as other users, are struggling with this aspect.

Of course, I can see that the solution is possible by looking at your sample code. However, finding it isn't straightforward.

![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/c721032b-6bb3-4843-9ee0-72ccd1f8001a)
The code is relatively straightforward as shown in the image above, but it took me quite a bit of time to solve this problem.

So, here's a suggestion:

While having various constraints is great, I believe that fundamentally knowing the required status in the documentation would be very helpful. I think this can be easily addressed by utilizing the optional attribute.

I kindly request you to review my pull request.

Finally, I'm not proficient in English, so I wrote this text using a translation tool. Please keep that in mind.

Thank you!!
