### PR TITLE
Feat : apply optional is nullable

### DIFF
--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -208,22 +208,15 @@ class JsonSchemaFromFieldDescriptorsGenerator {
 
         fun jsonSchemaType(): Schema {
             val schemaBuilders = jsonSchemaPrimitiveTypes.map { typeToSchema(it) }
-            return if (schemaBuilders.size == 1) {
-                val builder = schemaBuilders.first().description(description)
-                checkNullable(builder)
-                builder.build()
-            } else {
-                val builder = oneOf(schemaBuilders.map { it.build() }).description(description)
-                checkNullable(builder)
-                builder.build()
-            }
+            return if (schemaBuilders.size == 1) schemaBuilders.first().description(description).checkNullable().build()
+            else oneOf(schemaBuilders.map { it.build() }).description(description).checkNullable().build()
         }
 
-        private fun checkNullable(builder: Schema.Builder<out Schema>): Schema.Builder<out Schema> {
+        private fun Schema.Builder<out Schema>.checkNullable(): Schema.Builder<out Schema> {
             if (optional) {
-                builder.nullable(true)
+                this.nullable(true)
             }
-            return builder
+            return this
         }
 
         fun merge(fieldDescriptor: FieldDescriptor): FieldDescriptorWithSchemaType {

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -256,7 +256,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
 
         private fun arrayItemsSchema(): Schema {
             return attributes.itemsType
-                ?.let { typeToSchema(it.toLowerCase()).build() }
+                ?.let { typeToSchema(it.lowercase()).build() }
                 ?: CombinedSchema.oneOf(
                     listOf(
                         ObjectSchema.builder().build(),
@@ -285,7 +285,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
                 )
 
             private fun jsonSchemaPrimitiveTypeFromDescriptorType(fieldDescriptorType: String) =
-                fieldDescriptorType.toLowerCase()
+                fieldDescriptorType.lowercase()
                     .let { if (it == "varies") "empty" else it } // varies is used by spring rest docs if the type is ambiguous - in json schema we want to represent as empty
         }
     }

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -456,8 +456,6 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
             .build()
             .load()
             .build()
-//        schema = SchemaLoader.load(schemaString)
-//        schema = SchemaLoader.load(JSONObject(schemaString))
     }
 
     private fun givenFieldDescriptorWithPrimitiveArray() {

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -599,9 +599,9 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
 
     private fun givenDifferentFieldDescriptorsWithSamePathAndDifferentTypes() {
         fieldDescriptors = listOf(
-            FieldDescriptor("id", "some", "STRING"),
-            FieldDescriptor("id", "some", "NULL"),
-            FieldDescriptor("id", "some", "BOOLEAN")
+            FieldDescriptor("id", "some", "STRING", true),
+            FieldDescriptor("id", "some", "NULL", true),
+            FieldDescriptor("id", "some", "BOOLEAN", true)
         )
     }
 

--- a/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
+++ b/restdocs-api-spec-jsonschema/src/test/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGeneratorTest.kt
@@ -19,6 +19,7 @@ import org.everit.json.schema.Schema
 import org.everit.json.schema.StringSchema
 import org.everit.json.schema.ValidationException
 import org.everit.json.schema.loader.SchemaLoader
+import org.everit.json.schema.loader.internal.DefaultSchemaClient
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.jupiter.api.Test
@@ -61,6 +62,7 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
         val shippingAddressSchema = objectSchema.propertySchemas["shippingAddress"]!!
         then(shippingAddressSchema).isInstanceOf(ObjectSchema::class.java)
         then(shippingAddressSchema.description).isNotEmpty()
+        then(shippingAddressSchema.isNullable).isTrue()
 
         then(objectSchema.definesProperty("billingAddress")).isTrue()
         val billingAddressSchema = objectSchema.propertySchemas["billingAddress"] as ObjectSchema
@@ -120,6 +122,7 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
         then(pagePositiveSchema.minimum.toInt()).isEqualTo(1)
         then(pagePositiveSchema.maximum).isNull()
         then(pagePositiveSchema.requiresInteger()).isTrue
+        then(pagePositiveSchema.isNullable).isTrue()
 
         then(objectSchema.definesProperty("page100_200")).isTrue
         then(objectSchema.propertySchemas["page100_200"]).isInstanceOf(NumberSchema::class.java)
@@ -445,7 +448,16 @@ class JsonSchemaFromFieldDescriptorsGeneratorTest {
     private fun whenSchemaGenerated() {
         schemaString = generator.generateSchema(fieldDescriptors!!)
         println(schemaString)
-        schema = SchemaLoader.load(JSONObject(schemaString))
+        schema = SchemaLoader
+            .builder()
+            .nullableSupport(true)
+            .schemaJson(JSONObject(schemaString))
+            .schemaClient(DefaultSchemaClient())
+            .build()
+            .load()
+            .build()
+//        schema = SchemaLoader.load(schemaString)
+//        schema = SchemaLoader.load(JSONObject(schemaString))
     }
 
     private fun givenFieldDescriptorWithPrimitiveArray() {


### PR DESCRIPTION
# summary
- Optional fields are nullable.

# story
- Hey, I'm back again. First of all, thank you so much, I'm still using your open source.
- Today's request is...
- Currently, in the Swagger schema created through this, the optional fields are expressed as follows.
![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/27908230-b618-4347-b9f1-8eefa95043a9)
![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/f5119b99-27b5-45e6-9f63-b1295fa1f5b5)
- But our front engineer requested that it be expressed as below.
![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/9339af29-83da-4c3d-ae18-862ea8c3e835)
![image](https://github.com/ePages-de/restdocs-api-spec/assets/81915068/ab001902-4dc1-4f5c-b475-a0f1c7865663)
- It was explained well in [link here](https://swagger.io/docs/specification/data-models/data-types/#null).
- So, I modified the code a little to express it as above, relying on the optional field to handle the nullable of jsonSchema.

# Thanks
Please take care of this Pull Request as well.
Finally, I'm not proficient in English, so I wrote this text using a translation tool. Please keep that in mind.
Thank you!!
