### PR TITLE
fix: Schema is null

### DIFF
--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -86,7 +86,7 @@ object OpenApi3Generator {
 
     private fun OpenAPI.makeSubSchema() {
         val schemas = this.components.schemas
-        val subSchemas = mutableMapOf<String, Schema<Any>>()
+        val subSchemas = mutableMapOf<String, Schema<Any>?>()
         schemas.forEach {
             val schema = it.value
             if (schema.properties != null) {
@@ -99,14 +99,14 @@ object OpenApi3Generator {
         }
     }
 
-    private fun makeSubSchema(schemas: MutableMap<String, Schema<Any>>, properties: Map<String, Schema<Any>>) {
-        properties.asSequence().filter { it.value.title != null }.forEach {
+    private fun makeSubSchema(schemas: MutableMap<String, Schema<Any>?>, properties: Map<String, Schema<Any>?>) {
+        properties.asSequence().filter { it.value?.title != null }.forEach {
             val objectMapper = jacksonObjectMapper()
             val subSchema = it.value
             val strSubSchema = objectMapper.writeValueAsString(subSchema)
-            val copySchema = objectMapper.readValue(strSubSchema, subSchema.javaClass)
+            val copySchema = objectMapper.readValue(strSubSchema, subSchema?.javaClass)
             val schemaTitle = copySchema.title
-            subSchema.`$ref`("#/components/schemas/$schemaTitle")
+            subSchema?.`$ref`("#/components/schemas/$schemaTitle")
             schemas[schemaTitle] = copySchema
             makeSubSchema(schemas, copySchema.properties)
         }

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -1101,6 +1101,11 @@ class OpenApi3GeneratorTest {
                     type = "STRING"
                 ),
                 FieldDescriptor(
+                    path = "null_value",
+                    description = "null_value",
+                    type = "NULL"
+                ),
+                FieldDescriptor(
                     path = "option",
                     description = "option",
                     type = "OBJECT",


### PR DESCRIPTION
Hello, it's been a long time.
I came across this [issue](https://github.com/ePages-de/restdocs-api-spec/issues/251).
It has affected the outcome of my work. I'm sorry.

There is a problem when the type of a Field is null,
so I fixed the issue regarding this.
`fieldWithPath("null_data").description("null data").type(JsonFieldType.NULL)`
or
`fieldWithPath("null_data").description("null data")`

Please check it out.

Thanks as always.