### PR TITLE
Fix/fails when a field is not given a description

### DIFF
--- a/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
+++ b/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
@@ -115,7 +115,14 @@ abstract class ApiSpecTaskTest {
     "status" : 200,
     "contentType" : "application/hal+json",
     "headers" : [ ],
-    "responseFields" : [ ],
+    "responseFields" : [ {
+      "attributes" : { },
+      "description" : null,
+      "ignored" : false,
+      "path" : "name",
+      "type" : "STRING",
+      "optional" : false
+    } ],
     "example" : "{\n  \"name\" : \"Fancy pants\",\n  \"price\" : 49.99,\n  \"_links\" : {\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    },\n    \"product\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    }\n  }\n}"
   }
 }
@@ -160,7 +167,14 @@ abstract class ApiSpecTaskTest {
     "status" : 200,
     "contentType" : "application/hal+json",
     "headers" : [ ],
-    "responseFields" : [ ],
+    "responseFields" : [ {
+      "attributes" : { },
+      "description" : null,
+      "ignored" : false,
+      "path" : "name",
+      "type" : "STRING",
+      "optional" : false
+    } ],
     "example" : "{\n  \"name\" : \"Fancy pants\",\n  \"price\" : 49.99,\n  \"_links\" : {\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    },\n    \"product\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    }\n  }\n}"
   }
 }
@@ -194,7 +208,14 @@ abstract class ApiSpecTaskTest {
     "status" : 200,
     "contentType" : "application/hal+json",
     "headers" : [ ],
-    "responseFields" : [ ],
+    "responseFields" : [ {
+      "attributes" : { },
+      "description" : null,
+      "ignored" : false,
+      "path" : "name",
+      "type" : "STRING",
+      "optional" : false
+    } ],
     "example" : "{\n  \"name\" : \"Fancy pants\",\n  \"price\" : 49.99,\n  \"_links\" : {\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    },\n    \"product\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    }\n  }\n}"
   }
 }

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -196,7 +196,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
 
     internal class FieldDescriptorWithSchemaType(
         path: String,
-        description: String,
+        description: String?,
         type: String,
         optional: Boolean,
         ignored: Boolean,

--- a/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
+++ b/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
@@ -81,7 +81,7 @@ data class HeaderDescriptor(
 
 open class FieldDescriptor(
     val path: String,
-    val description: String,
+    val description: String?,
     val type: String,
     val optional: Boolean = false,
     val ignored: Boolean = false,


### PR DESCRIPTION
Found and fixed an issue where openapi3 task would fail if no description was provided.  #121

I think this is a problem for all tasks, not just the openapi3 task.
So I changed the description field in the model to nullable.

If you're having trouble with this change, I'd appreciate direction.