### PR TITLE
Feature: Support Request Parts

### DIFF
--- a/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
+++ b/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
@@ -237,4 +237,61 @@ abstract class ApiSpecTaskTest {
     protected fun givenBuildFileWithoutApiSpecClosure() {
         buildFile.writeText(baseBuildFile())
     }
+
+    fun givenResourceSnippetWithRequestParts() {
+        val operationDir = File(snippetsFolder, "some-operation").apply { mkdir() }
+        File(operationDir, "resource.json").writeText(
+            """
+                {
+  "operationId" : "product-photo-upload",
+  "summary" : null,
+  "description" : null,
+  "privateResource" : false,
+  "deprecated" : false,
+  "request" : {
+    "path" : "/products/photo/{id}",
+    "method" : "POST",
+    "contentType" : "multipart/form-data",
+    "headers" : [ {
+      "name" : "one",
+      "attributes" : { },
+      "description" : "Override request header param",
+      "type" : "STRING",
+      "optional" : true,
+      "example" : "one",
+      "default" : "a default value"
+    } ],
+    "pathParameters" : [ ],
+    "queryParameters" : [ ],
+    "formParameters" : [ ],
+    "requestFields" : [ ],
+    "requestParts" : [
+        {
+            "content" : "dGVzdA==",
+            "headers" : {
+                "Content-Type" : [ "image/jpeg" ],
+                "Content-Length" : [ "123" ]
+            },
+            "name" : "photo",
+            "submittedFileName" : "photo.jpg",
+            "contentAsString" : "photo"
+        }
+    ],
+    "example" : null,
+    "securityRequirements" : {
+      "type": "OAUTH2",
+      "requiredScopes": ["prod:r"]
+    }
+  },
+  "response" : {
+    "status" : 200,
+    "contentType" : "application/hal+json",
+    "headers" : [ ],
+    "responseFields" : [ ],
+    "example" : "{\n  \"name\" : \"Fancy pants\",\n  \"price\" : 49.99,\n  \"_links\" : {\n    \"self\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    },\n    \"product\" : {\n      \"href\" : \"http://localhost:8080/products/7\"\n    }\n  }\n}"
+  }
+}
+            """.trimIndent()
+        )
+    }
 }

--- a/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
+++ b/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/ApiSpecTaskTest.kt
@@ -105,6 +105,7 @@ abstract class ApiSpecTaskTest {
     "queryParameters" : [ ],
     "formParameters" : [ ],
     "requestFields" : [ ],
+    "requestParts" : [ ],
     "example" : null,
     "securityRequirements" : {
       "type": "OAUTH2",
@@ -150,6 +151,7 @@ abstract class ApiSpecTaskTest {
     "queryParameters" : [ ],
     "formParameters" : [ ],
     "requestFields" : [ ],
+    "requestParts" : [ ],
     "example" : null,
     "securityRequirements" : {
       "type": "OAUTH2",
@@ -187,6 +189,7 @@ abstract class ApiSpecTaskTest {
     "queryParameters" : [ ],
     "formParameters" : [ ],
     "requestFields" : [ ],
+    "requestParts" : [ ],
     "example" : null,
     "securityRequirements" : null
   },

--- a/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/PostmanTaskTest.kt
+++ b/restdocs-api-spec-gradle-plugin/src/test/kotlin/com/epages/restdocs/apispec/gradle/PostmanTaskTest.kt
@@ -63,6 +63,36 @@ class PostmanTaskTest : ApiSpecTaskTest() {
         thenOutputFileForPublicResourceSpecificationFound()
     }
 
+    @Test
+    fun `should run postman task with request parts`() {
+        title = "my custom title"
+        version = "2.0.0"
+        baseUrl = "https://example.com:8080/api"
+
+        givenBuildFileWithPostmanClosure()
+        givenResourceSnippetWithRequestParts()
+
+        whenPluginExecuted()
+
+        thenApiSpecTaskSuccessful()
+        thenOutputFileFound()
+        thenOutputFileForPublicResourceSpecificationNotFound()
+
+        with(outputFileContext()) {
+            then(read<String>("info.name")).isEqualTo(title)
+            then(read<String>("info.version")).isEqualTo(version)
+            then(read<String>("item[0].request.url.protocol")).isEqualTo("https")
+            then(read<String>("item[0].request.url.host")).isEqualTo("example.com")
+            then(read<String>("item[0].request.url.port")).isEqualTo("8080")
+            then(read<String>("item[0].request.url.path")).isEqualTo("/api/products/photo/:id")
+            then(read<String>("item[0].request.header[1].value")).isEqualTo("multipart/form-data")
+            then(read<String>("item[0].request.body.mode")).isEqualTo("formdata")
+            then(read<String>("item[0].request.body.formdata[0].key")).isEqualTo("photo")
+            then(read<String>("item[0].request.body.formdata[0].type")).isEqualTo("file")
+            then(read<List<String>>("item[0].request.body.formdata[0].src")).isEmpty()
+        }
+    }
+
     private fun givenBuildFileWithPostmanClosure() {
         buildFile.writeText(
             baseBuildFile() + """

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/JsonSchemaFromFieldDescriptorsGenerator.kt
@@ -8,6 +8,7 @@ import com.epages.restdocs.apispec.jsonschema.ConstraintResolver.maybeMinSizeArr
 import com.epages.restdocs.apispec.jsonschema.ConstraintResolver.maybePattern
 import com.epages.restdocs.apispec.jsonschema.ConstraintResolver.minInteger
 import com.epages.restdocs.apispec.jsonschema.ConstraintResolver.minLengthString
+import com.epages.restdocs.apispec.jsonschema.schema.FileSchema
 import com.epages.restdocs.apispec.model.Attributes
 import com.epages.restdocs.apispec.model.FieldDescriptor
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -265,6 +266,7 @@ class JsonSchemaFromFieldDescriptorsGenerator {
                         EnumSchema.builder().possibleValues(this.attributes.enumValues).build()
                     )
                 ).isSynthetic(true)
+                "file" -> FileSchema.builder()
                 else -> throw IllegalArgumentException("unknown field type $type")
             }
 

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/schema/FileSchema.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/schema/FileSchema.kt
@@ -1,0 +1,50 @@
+package com.epages.restdocs.apispec.jsonschema.schema
+
+import org.everit.json.schema.EmptySchema
+import org.everit.json.schema.internal.JSONPrinter
+
+class FileSchema(
+    builder: BinarySchemaBuilder
+) : EmptySchema(builder) {
+
+    val format: String = builder.format
+    class BinarySchemaBuilder : EmptySchema.Builder() {
+
+        internal var format: String = "binary"
+
+        override fun build(): FileSchema {
+            return FileSchema(this)
+        }
+
+        fun format(format : String) : BinarySchemaBuilder {
+            this.format = format
+            return this
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun builder(): BinarySchemaBuilder {
+            return BinarySchemaBuilder()
+        }
+    }
+
+    override fun describeTo(writer: JSONPrinter) {
+        writer.`object`()
+        writer.ifPresent("title", super.getTitle())
+        writer.ifPresent("description", super.getDescription())
+        writer.ifPresent("id", super.getId())
+        writer.ifPresent("default", super.getDefaultValue())
+        writer.ifPresent("nullable", super.isNullable())
+        writer.ifPresent("readOnly", super.isReadOnly())
+        writer.ifPresent("writeOnly", super.isWriteOnly())
+        writer.key("type").value("string")
+        writer.key("format").value(format)
+        super.getUnprocessedProperties().forEach { (key: String?, `val`: Any?) ->
+            writer.key(
+                key
+            ).value(`val`)
+        }
+        writer.endObject()
+    }
+}

--- a/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/schema/FileSchema.kt
+++ b/restdocs-api-spec-jsonschema/src/main/kotlin/com/epages/restdocs/apispec/jsonschema/schema/FileSchema.kt
@@ -1,14 +1,15 @@
 package com.epages.restdocs.apispec.jsonschema.schema
 
-import org.everit.json.schema.EmptySchema
+import org.everit.json.schema.StringSchema
 import org.everit.json.schema.internal.JSONPrinter
 
 class FileSchema(
     builder: BinarySchemaBuilder
-) : EmptySchema(builder) {
+) : StringSchema(builder) {
 
     val format: String = builder.format
-    class BinarySchemaBuilder : EmptySchema.Builder() {
+
+    class BinarySchemaBuilder : StringSchema.Builder() {
 
         internal var format: String = "binary"
 

--- a/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
+++ b/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
@@ -1,7 +1,7 @@
 package com.epages.restdocs.apispec.model
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.util.Comparator
 
 data class ResourceModel(
     val operationId: String,
@@ -40,6 +40,7 @@ data class RequestModel(
     val queryParameters: List<ParameterDescriptor>,
     val formParameters: List<ParameterDescriptor>,
     val requestFields: List<FieldDescriptor>,
+    val requestParts: List<RequestPartFieldDescriptor>,
     val example: String? = null,
     val schema: Schema? = null
 )
@@ -86,6 +87,47 @@ open class FieldDescriptor(
     val optional: Boolean = false,
     val ignored: Boolean = false,
     val attributes: Attributes = Attributes()
+)
+
+open class RequestPartFieldDescriptor(
+    val name: String,
+    val submittedFileName: String?,
+    val content: ByteArray,
+    val headers: RequestPartHeaderDescriptor,
+    val optional: Boolean = false,
+    val ignored: Boolean = false,
+    val attributes: Attributes = Attributes()
+) {
+    companion object {
+        private val FILE_TYPES = listOf(
+            "application/msword",
+            "application/pdf",
+            "application/vnd.ms-excel",
+            "application/x-javascript",
+            "application/zip",
+            "image/jpeg",
+            "image/jpg",
+            "image/jpe",
+            "text/css",
+            "text/html",
+            "text/htm",
+            "text/plain",
+            "text/xml",
+            "text/xsl"
+        )
+    }
+    val type: String = when {
+        headers.contentType?.any { it in FILE_TYPES } == true -> "file"
+        else -> "string"
+    }
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class RequestPartHeaderDescriptor(
+    @JsonProperty("Content-Type")
+    val contentType: List<String>?,
+    @JsonProperty("Content-Length")
+    val contentLength: List<Long>?,
 )
 
 data class Attributes(

--- a/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
+++ b/restdocs-api-spec-openapi-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20Generator.kt
@@ -6,6 +6,7 @@ import com.epages.restdocs.apispec.model.HTTPMethod
 import com.epages.restdocs.apispec.model.HeaderDescriptor
 import com.epages.restdocs.apispec.model.Oauth2Configuration
 import com.epages.restdocs.apispec.model.ParameterDescriptor
+import com.epages.restdocs.apispec.model.RequestPartFieldDescriptor
 import com.epages.restdocs.apispec.model.ResourceModel
 import com.epages.restdocs.apispec.model.ResponseModel
 import com.epages.restdocs.apispec.model.Schema
@@ -312,7 +313,12 @@ object OpenApi20Generator {
                             firstModelForPathAndMethod.request.schema
                         )
                     )
-                ).nullIfEmpty()
+                ).plus(
+                    modelsWithSamePathAndMethod
+                        .flatMap { it.request.requestParts }
+                        .map { part2Parameters(it) }
+                )
+                    .nullIfEmpty()
             responses = responsesByStatusCode(
                 modelsWithSamePathAndMethod
             )
@@ -475,6 +481,16 @@ object OpenApi20Generator {
             }
         } else {
             null
+        }
+    }
+
+    private fun part2Parameters(partDescriptor: RequestPartFieldDescriptor): FormParameter {
+        return FormParameter().apply {
+            name = partDescriptor.name
+            description = partDescriptor.submittedFileName
+            required = partDescriptor.optional
+            type = partDescriptor.type
+            default = partDescriptor.content
         }
     }
 

--- a/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
+++ b/restdocs-api-spec-openapi-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi2/OpenApi20GeneratorTest.kt
@@ -914,7 +914,8 @@ class OpenApi20GeneratorTest {
                 )
             ),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -943,7 +944,8 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -960,7 +962,8 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -977,7 +980,8 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -1123,6 +1127,7 @@ class OpenApi20GeneratorTest {
                 )
             ),
             requestFields = listOf(),
+            requestParts = listOf(),
             example = """
                     locale=pl&irrelevant=true
             """.trimIndent()
@@ -1173,6 +1178,7 @@ class OpenApi20GeneratorTest {
                     attributes = Attributes(enumValues = listOf("FIRST_VALUE", "SECOND_VALUE", "THIRD_VALUE"))
                 )
             ),
+            requestParts = listOf(),
             example = getProductPayloadExample()
         )
     }
@@ -1197,7 +1203,8 @@ class OpenApi20GeneratorTest {
             ),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -1213,7 +1220,8 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -1229,7 +1237,8 @@ class OpenApi20GeneratorTest {
             pathParameters = listOf(),
             queryParameters = listOf(),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 

--- a/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
+++ b/restdocs-api-spec-openapi3-generator/src/main/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3Generator.kt
@@ -7,6 +7,7 @@ import com.epages.restdocs.apispec.model.HTTPMethod
 import com.epages.restdocs.apispec.model.HeaderDescriptor
 import com.epages.restdocs.apispec.model.Oauth2Configuration
 import com.epages.restdocs.apispec.model.ParameterDescriptor
+import com.epages.restdocs.apispec.model.RequestPartFieldDescriptor
 import com.epages.restdocs.apispec.model.RequestModel
 import com.epages.restdocs.apispec.model.ResourceModel
 import com.epages.restdocs.apispec.model.ResponseModel
@@ -329,7 +330,11 @@ object OpenApi3Generator {
                     requestFields = requests.flatMap { it ->
                         if (it.request.contentType == "application/x-www-form-urlencoded") {
                             it.request.formParameters.map { parameterDescriptor2FieldDescriptor(it) }
-                        } else {
+                        }
+                        else if (it.request.contentType == "multipart/form-data") {
+                            it.request.requestParts.map { partDescriptor2FieldDescriptor(it) }
+                        }
+                        else {
                             it.request.requestFields
                         }
                     },
@@ -440,6 +445,19 @@ object OpenApi3Generator {
             optional = parameterDescriptor.optional,
             ignored = parameterDescriptor.ignored,
             attributes = parameterDescriptor.attributes
+        )
+    }
+
+    private fun partDescriptor2FieldDescriptor(
+        partDescriptor: RequestPartFieldDescriptor
+    ): FieldDescriptor {
+        return FieldDescriptor(
+            path = partDescriptor.name,
+            description = partDescriptor.submittedFileName ?: "",
+            type = partDescriptor.type,
+            optional = partDescriptor.optional,
+            ignored = partDescriptor.optional,
+            attributes = partDescriptor.attributes
         )
     }
 

--- a/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
+++ b/restdocs-api-spec-openapi3-generator/src/test/kotlin/com/epages/restdocs/apispec/openapi3/OpenApi3GeneratorTest.kt
@@ -928,7 +928,8 @@ class OpenApi3GeneratorTest {
                     queryParameters = listOf(),
                     formParameters = listOf(),
                     securityRequirements = null,
-                    requestFields = listOf()
+                    requestFields = listOf(),
+                    requestParts = listOf()
                 ),
                 response = ResponseModel(
                     status = 204,
@@ -1185,6 +1186,7 @@ class OpenApi3GeneratorTest {
                     attributes = Attributes(enumValues = listOf("FIRST_VALUE", "SECOND_VALUE", "THIRD_VALUE"))
                 )
             ),
+            requestParts = listOf(),
             contentType = "application/json",
             example = """{
                 "description": "Good stuff!",
@@ -1218,6 +1220,7 @@ class OpenApi3GeneratorTest {
                     type = "STRING"
                 )
             ),
+            requestParts = listOf(),
             contentType = "application/json-patch+json",
             example = """
                 [
@@ -1263,6 +1266,7 @@ class OpenApi3GeneratorTest {
                     type = "STRING"
                 ),
             ),
+            requestParts = listOf(),
             contentType = "application/json",
             example = """
                 {
@@ -1286,7 +1290,8 @@ class OpenApi3GeneratorTest {
             pathParameters = emptyList(),
             queryParameters = emptyList(),
             formParameters = emptyList(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 
@@ -1310,6 +1315,7 @@ class OpenApi3GeneratorTest {
             ),
             schema = schema,
             requestFields = listOf(),
+            requestParts = listOf(),
             example = """
                     locale=pl&irrelevant=true
             """.trimIndent()
@@ -1349,7 +1355,8 @@ class OpenApi3GeneratorTest {
                 )
             ),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf(),
         )
     }
 
@@ -1636,7 +1643,8 @@ class OpenApi3GeneratorTest {
             ),
             formParameters = listOf(),
             pathParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf(),
         )
     }
 

--- a/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/Body.java
+++ b/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/Body.java
@@ -32,6 +32,8 @@ public class Body {
     private String raw;
     @JsonProperty("urlencoded")
     private List<Urlencoded> urlencoded = new ArrayList<Urlencoded>();
+    @JsonProperty("formdata")
+    private List<FormData> formData = new ArrayList<FormData>();
 
     /**
      * Postman stores the type of data associated with this request in this field.
@@ -69,6 +71,16 @@ public class Body {
     @JsonProperty("urlencoded")
     public void setUrlencoded(List<Urlencoded> urlencoded) {
         this.urlencoded = urlencoded;
+    }
+
+    @JsonProperty("formdata")
+    public List<FormData> getFormData() {
+        return formData;
+    }
+
+    @JsonProperty("formdata")
+    public void setFormData(List<FormData> formData) {
+        this.formData = formData;
     }
 
     public enum Mode {

--- a/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/Body.java
+++ b/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/Body.java
@@ -17,7 +17,8 @@ import java.util.Map;
 @JsonPropertyOrder({
     "mode",
     "raw",
-    "urlencoded"
+    "urlencoded",
+    "formdata"
 })
 public class Body {
 

--- a/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/FormData.java
+++ b/restdocs-api-spec-postman-generator/src/main/java/com/epages/restdocs/apispec/postman/model/FormData.java
@@ -1,0 +1,121 @@
+package com.epages.restdocs.apispec.postman.model;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
+
+/**
+ * FormData
+ * <p>
+ *
+ *
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "key",
+    "type",
+    "src",
+    "description",
+
+})
+public class FormData {
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("key")
+    private String key;
+    /**
+     * A Type can be text, or be file
+     *
+     */
+    @JsonProperty("type")
+    private String type;
+    /**
+     * The path to file, on the file system
+     *
+     */
+    @JsonProperty("src")
+    private List<String> src;
+    /**
+     * A Description can be a raw text, or be an object, which holds the description along with its format.
+     *
+     */
+    @JsonProperty("description")
+    @JsonPropertyDescription("A Description can be a raw text, or be an object, which holds the description along with its format.")
+    private String description;
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("key")
+    public String getKey() {
+        return key;
+    }
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("key")
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * A Type can be text, or be file
+     *
+     */
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * A Type can be text, or be file
+     *
+     */
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+    /**
+     * The path to file, on the file system
+     *
+     */
+    @JsonProperty("src")
+    public List<String> getSrc() {
+        return src;
+    }
+
+    /**
+     * The path to file, on the file system
+     *
+     */
+    @JsonProperty("src")
+    public void setSrc(List<String> src) {
+        this.src = src;
+    }
+    /**
+     * A Description can be a raw text, or be an object, which holds the description along with its format.
+     *
+     */
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+    /**
+     * A Description can be a raw text, or be an object, which holds the description along with its format.
+     *
+     */
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/restdocs-api-spec-postman-generator/src/test/kotlin/com/epages/restdocs/apispec/postman/PostmanCollectionGeneratorTest.kt
+++ b/restdocs-api-spec-postman-generator/src/test/kotlin/com/epages/restdocs/apispec/postman/PostmanCollectionGeneratorTest.kt
@@ -220,7 +220,8 @@ internal class PostmanCollectionGeneratorTest {
                     queryParameters = listOf(),
                     formParameters = listOf(),
                     securityRequirements = null,
-                    requestFields = listOf()
+                    requestFields = listOf(),
+                    requestParts = listOf()
                 ),
                 response = ResponseModel(
                     status = 204,
@@ -337,6 +338,7 @@ internal class PostmanCollectionGeneratorTest {
                     type = "STRING"
                 )
             ),
+            requestParts = listOf(),
             contentType = "application/json",
             example = """{
                 "description": "Good stuff!"
@@ -370,6 +372,7 @@ internal class PostmanCollectionGeneratorTest {
                     type = "STRING"
                 )
             ),
+            requestParts = listOf(),
             contentType = "application/json-patch+json",
             example = """
                 [
@@ -419,7 +422,8 @@ internal class PostmanCollectionGeneratorTest {
                 )
             ),
             formParameters = listOf(),
-            requestFields = listOf()
+            requestFields = listOf(),
+            requestParts = listOf()
         )
     }
 

--- a/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippet.kt
+++ b/restdocs-api-spec/src/main/kotlin/com/epages/restdocs/apispec/ResourceSnippet.kt
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.restdocs.RestDocumentationContext
 import org.springframework.restdocs.generate.RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE
 import org.springframework.restdocs.operation.Operation
+import org.springframework.restdocs.operation.OperationRequestPart
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.snippet.PlaceholderResolverFactory
 import org.springframework.restdocs.snippet.RestDocumentationContextPlaceholderResolverFactory
@@ -48,6 +49,7 @@ class ResourceSnippet(private val resourceSnippetParameters: ResourceSnippetPara
 
         val hasRequestBody = operation.request.contentAsString.isNotEmpty()
         val hasResponseBody = operation.response.contentAsString.isNotEmpty()
+        val hasPart = operation.request.parts.isNotEmpty()
 
         val securityRequirements = SecurityRequirementsHandler().extractSecurityRequirements(operation)
 
@@ -68,13 +70,14 @@ class ResourceSnippet(private val resourceSnippetParameters: ResourceSnippetPara
             request = RequestModel(
                 path = getUriPath(operation),
                 method = operation.request.method.name(),
-                contentType = if (hasRequestBody) getContentTypeOrDefault(operation.request.headers) else null,
+                contentType = if (hasRequestBody || hasPart) getContentTypeOrDefault(operation.request.headers) else null,
                 headers = resourceSnippetParameters.requestHeaders.withExampleValues(operation.request.headers),
                 pathParameters = resourceSnippetParameters.pathParameters.filter { !it.isIgnored },
                 queryParameters = resourceSnippetParameters.queryParameters.filter { !it.isIgnored },
                 formParameters = resourceSnippetParameters.formParameters.filter { !it.isIgnored },
                 schema = resourceSnippetParameters.requestSchema,
                 requestFields = if (hasRequestBody) resourceSnippetParameters.requestFields.filter { !it.isIgnored } else emptyList(),
+                requestParts = operation.request.parts.toList(),
                 example = if (hasRequestBody) operation.request.contentAsString else null,
                 securityRequirements = securityRequirements
             ),
@@ -139,6 +142,7 @@ class ResourceSnippet(private val resourceSnippetParameters: ResourceSnippetPara
         val queryParameters: List<ParameterDescriptorWithType>,
         val formParameters: List<ParameterDescriptorWithType>,
         val requestFields: List<FieldDescriptor>,
+        val requestParts: List<OperationRequestPart>,
         val example: String?,
         val securityRequirements: SecurityRequirements?
     )


### PR DESCRIPTION
Related Isssue: #105 , #205 

_I am not good at English.
If there's anything you don't understand, please leave a comment._ 

I know swagger and postman support file type.

**- Swagger**
![스크린샷 2024-09-07 오후 3 06 58](https://github.com/user-attachments/assets/4febdd8d-93ea-438b-a204-db119092f3f5)

**- Postman**
![스크린샷 2024-09-07 오후 3 07 19](https://github.com/user-attachments/assets/feeea246-1863-4587-be07-038c24cd83de)


So I wrote the code to implement to support request with file.

### RequestModel
````
private data class RequestModel(
    ....
    val requestParts: List<OperationRequestPart>,
)
````
Add `requestParts` for multipart request.

### FileSchema, FormData
````
class FileSchema(
    builder: BinarySchemaBuilder
) : StringSchema(builder) {
    ...
    val format: String
}
````
````
@JsonPropertyOrder({
    "key",
    "type",
    "src",
    "description",

})
public class FormData {
    ....
}
````

Make `FileSchema/FormData` for `OpenApiGenerator/PostmanGenerator` to handle spec for file type.

In Generator they are added to `RequestModel` and `Body` 

````
data class RequestModel(
    ...
    // FileSchema -> RequestPartFieldDescriptor
    val requestParts: List<RequestPartFieldDescriptor>,
)
````
````
@JsonPropertyOrder({
    "mode",
    "raw",
    "urlencoded",
    "formdata"
})
public class Body  { ... }
```` 
