### PR TITLE
Make classes in restdocs-api-spec module visible in restassured module

### DIFF
--- a/restdocs-api-spec-restassured/build.gradle.kts
+++ b/restdocs-api-spec-restassured/build.gradle.kts
@@ -13,7 +13,7 @@ val junitVersion: String by extra
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
-    implementation(project(":restdocs-api-spec"))
+    api(project(":restdocs-api-spec"))
     implementation("org.springframework.restdocs:spring-restdocs-restassured:$springRestDocsVersion")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion") {


### PR DESCRIPTION
Hi, I raised an issue last week, but I think you might have missed it, so I’ve also created a PR.

As I mentioned in the issue #272, there’s a problem where the restassured module can’t reference classes from the restdocs-api-spec module. To fix this, I simply changed the implementation to api in the build.gradle.kts file.

You can see a similar change that was made for mockmvc before: #222