### PR TITLE
fix: update class signature to adapt Jackson 2.18 changes in deserialization of data class

### DIFF
--- a/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
+++ b/restdocs-api-spec-model/src/main/kotlin/com/epages/restdocs/apispec/model/ResourceModel.kt
@@ -1,5 +1,6 @@
 package com.epages.restdocs.apispec.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.Comparator
 
@@ -26,7 +27,7 @@ fun List<ResourceModel>.groupByPath(): Map<String, List<ResourceModel>> {
         .groupBy { it.request.path }
 }
 
-data class Schema(
+data class Schema @JsonCreator constructor(
     val name: String
 )
 


### PR DESCRIPTION
With Jackson 2.18.2, while deserializing the Schema class it gives below exception

Cannot construct instance of `com.epages.restdocs.apispec.model.Schema` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; line: 83, column: 7] (through reference chain: com.epages.restdocs.apispec.model.ResourceModel["response"]->com.epages.restdocs.apispec.model.ResponseModel["schema"])

and to resolve it Jackson library provided the workaround used in the MR changes