### PR TITLE
Fix: Remove duplicate annotations

### DIFF
--- a/samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/apispec/sample/CartIntegrationTest.java
+++ b/samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/apispec/sample/CartIntegrationTest.java
@@ -24,10 +24,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@SpringBootTest
 @ExtendWith(SpringExtension.class)
+@AutoConfigureRestDocs
 public class CartIntegrationTest extends BaseIntegrationTest {
 
     String cartId;

--- a/samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/apispec/sample/ProductRestIntegrationTest.java
+++ b/samples/restdocs-api-spec-sample/src/test/java/com/epages/restdocs/apispec/sample/ProductRestIntegrationTest.java
@@ -35,9 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
 @ExtendWith(SpringExtension.class)
-@AutoConfigureMockMvc
 @AutoConfigureRestDocs
 public class ProductRestIntegrationTest extends BaseIntegrationTest {
 


### PR DESCRIPTION
Hello, I'm using your library really well.

There is unnecessary redundant annotation in the example code. So I removed it.