### PR TITLE
feat: Add document method accepting ResourceSnippetParametersBuilder

### DIFF
--- a/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
+++ b/restdocs-api-spec-mockmvc/src/main/kotlin/com/epages/restdocs/apispec/MockMvcRestDocumentationWrapper.kt
@@ -111,6 +111,15 @@ object MockMvcRestDocumentationWrapper : RestDocumentationWrapper() {
     }
 
     @JvmStatic
+    fun document(
+        identifier: String,
+        resourceSnippetParametersBuilder: ResourceSnippetParametersBuilder
+    ): RestDocumentationResultHandler {
+        var resource = ResourceDocumentation.resource(resourceSnippetParametersBuilder.build())
+        return document(identifier, null, null, false, false, null, null, Function.identity(), resource)
+    }
+
+    @JvmStatic
     fun resourceDetails(): ResourceSnippetDetails {
         return ResourceSnippetParametersBuilder()
     }


### PR DESCRIPTION
I'm using your library well. 

It's possible to write like the code below, but there's a bug where responsefields and requestfields are initialized. So I added document parameters.

```java
resultActions
                .andExpect(status().isOk())
                .andDo(document("cart-get",
                                new ResourceSnippetParametersBuilder()
                                        .tag("cart")
                                        .description("Get a cart by id")
                                        .responseSchema(Schema.schema("ResponseCart"))
                                        .pathParameters(
                                                parameterWithName("id").description("the cart id"))
                                        .responseFields(
                                                fieldWithPath("total").description("Total amount of the cart."),
                                                fieldWithPath("products").description("The product line item of the cart."),
                                                subsectionWithPath("products[]._links.product").description("Link to the product."),
                                                fieldWithPath("products[].quantity").description("The quantity of the line item."),
                                                subsectionWithPath("products[].product").description("The product the line item relates to."),
                                                subsectionWithPath("_links").description("Links section."))
                                        .links(
                                                linkWithRel("self").ignored(),
                                                linkWithRel("order").description("Link to order the cart."))
                        )
                );
```